### PR TITLE
[FIX] widgettoolbox: Fix layout size hint for the widget tool box

### DIFF
--- a/orangecanvas/application/widgettoolbox.py
+++ b/orangecanvas/application/widgettoolbox.py
@@ -402,6 +402,7 @@ class WidgetToolBox(ToolBox):
 
         grid.setIconSize(self.__iconSize)
         grid.setButtonSize(self.__buttonSize)
+        grid.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
 
         text = item_text(item)
         icon = item_icon(item)


### PR DESCRIPTION

Due to change in ToolGridButton's size policy in 7059c5c5bb3fd37dee19624cb56b944ed66b62cd the grid no longer constrains the size in the vertical direction, causing the button grid to fill available space

<img width="257" alt="image" src="https://user-images.githubusercontent.com/4716745/60331124-3ed70800-9994-11e9-9869-05bf28852bdb.png">
