### PR TITLE
[ENH] Quick Menu Redesign

### DIFF
--- a/orangecanvas/application/canvastooldock.py
+++ b/orangecanvas/application/canvastooldock.py
@@ -8,8 +8,7 @@ from typing import Optional, Any
 
 from AnyQt.QtWidgets import (
     QWidget, QSplitter, QVBoxLayout, QAction, QSizePolicy, QApplication,
-    QToolButton
-)
+    QToolButton, QTreeView)
 from AnyQt.QtGui import QPalette, QBrush, QDrag, QResizeEvent, QHideEvent
 
 from AnyQt.QtCore import (
@@ -441,6 +440,7 @@ class CategoryPopupMenu(FramelessWindow):
         self.__dragListener.dragStarted.connect(self.__onDragStarted)
 
         self.__menu.view().viewport().installEventFilter(self.__dragListener)
+        self.__menu.view().installEventFilter(self)
 
         layout.addWidget(self.__menu)
 
@@ -512,6 +512,7 @@ class CategoryPopupMenu(FramelessWindow):
         geom = widget_popup_geometry(pos, self)
         self.setGeometry(geom)
         self.show()
+        self.__menu.view().setFocus()
 
     def exec_(self, pos=None):
         # type: (Optional[QPoint]) -> Optional[QAction]
@@ -570,6 +571,16 @@ class CategoryPopupMenu(FramelessWindow):
         drag.exec_(Qt.CopyAction)
 
         viewport.removeEventFilter(filter)
+
+    def eventFilter(self, obj, event):
+        if isinstance(obj, QTreeView) and event.type() == QEvent.KeyPress:
+            key = event.key()
+            if key in [Qt.Key_Return, Qt.Key_Enter]:
+                curr = obj.currentIndex()
+                if curr.isValid():
+                    obj.activated.emit(curr)
+                    return True
+        return super().eventFilter(obj, event)
 
 
 class ItemViewDragStartEventListener(QObject):

--- a/orangecanvas/application/canvastooldock.py
+++ b/orangecanvas/application/canvastooldock.py
@@ -23,8 +23,8 @@ from ..gui.toolgrid import ToolGrid
 from ..gui.toolbar import DynamicResizeToolBar
 from ..gui.quickhelp import QuickHelp
 from ..gui.framelesswindow import FramelessWindow
+from ..gui.utils import create_css_gradient
 from ..document.quickmenu import MenuPage
-from ..document.quickmenu import create_css_gradient
 from .widgettoolbox import WidgetToolBox, iter_index, item_text, item_icon, item_tooltip
 from ..registry.qt import QtWidgetRegistry
 

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -535,6 +535,7 @@ class NewLinkAction(UserInteraction):
                 return False
 
         menu.setFilterFunc(filter)
+        menu.triggerSearch()
         try:
             action = menu.exec_(pos)
         finally:

--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -289,6 +289,15 @@ class MenuPage(ToolTree):
                 height = height * count
             else:
                 height = 0
+
+            # accommodate width for scroll bar width on mac, should transient scrollbars be disabled
+            # System Preferences -> General -> Show scroll bars
+            if sys.platform == "darwin":
+                scroll = self.view().verticalScrollBar()
+                isTransient = scroll.style().styleHint(QStyle.SH_ScrollBar_Transient, widget=scroll)
+                if not isTransient:
+                    width += scroll.style().pixelMetric(QStyle.PM_ScrollBarExtent, widget=scroll)
+
             self.__sizeHint = QSize(width, height)
 
         return self.__sizeHint
@@ -1240,7 +1249,7 @@ class QuickMenu(FramelessWindow):
     def __init__(self, parent=None, **kwargs):
         # type: (Optional[QWidget], Any) -> None
         super().__init__(parent, **kwargs)
-        self.setWindowFlags(Qt.Popup)
+        self.setWindowFlags(self.windowFlags() | Qt.Popup)
 
         self.__filterFunc = None  # type: Optional[FilterFunc]
         self.__sortingFunc = None  # type: Optional[Callable[[Any, Any], bool]]

--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -1072,7 +1072,7 @@ class QuickMenu(FramelessWindow):
         self.__search = SearchWidget(self, objectName="search-line")
 
         self.__search.setPlaceholderText(
-            self.tr("Search for widget or select from the list.")
+            self.tr("Search for a widget...")
         )
 
         self.layout().addWidget(self.__search)

--- a/orangecanvas/gui/tooltree.py
+++ b/orangecanvas/gui/tooltree.py
@@ -45,7 +45,7 @@ class ToolTree(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         view = QTreeView(objectName="tool-tree-view")
-        view.setUniformRowHeights(True)
+        # view.setUniformRowHeights(True)  # causes several seconds delay upon first menu open
         view.setFrameStyle(QTreeView.NoFrame)
         view.setModel(self.__model)
         view.setRootIsDecorated(False)

--- a/orangecanvas/gui/utils.py
+++ b/orangecanvas/gui/utils.py
@@ -215,7 +215,7 @@ def css_gradient(gradient: QLinearGradient) -> str:
     stops = "\n".join("    stop: {0:f} {1}".format(stop, color.name())
                       for stop, color in stops)
     return ("qlineargradient(\n"
-            "    x1: {x1}, y1: {y1}, x2: {x1}, y2: {y2},\n"
+            "    x1: {x1}, y1: {y1}, x2: {x2}, y2: {y2},\n"
             "{stops})").format(x1=x1, y1=y1, x2=x2, y2=y2, stops=stops)
 
 

--- a/orangecanvas/gui/utils.py
+++ b/orangecanvas/gui/utils.py
@@ -13,8 +13,7 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtGui import (
     QGradient, QLinearGradient, QRadialGradient, QBrush, QPainter,
-    QPaintEvent, QColor,
-    QPixmap, QPixmapCache)
+    QPaintEvent, QColor, QPixmap, QPixmapCache)
 from AnyQt.QtCore import Qt, QPointF, QPoint, QRect, QRectF
 
 import sip
@@ -312,9 +311,9 @@ def innerGlowBackgroundPixmap(color, size, radius=5):
     a rounded-corner gradient rectangle pixmap.
 
     Args:
-        color: QColor - used as outer color (lightness 245 used for inner)
-        size: QSize - size of output pixmap
-        radius: int - radius of inner glow rounded corners
+        color (QColor): used as outer color (lightness 245 used for inner)
+        size (QSize): size of output pixmap
+        radius (int): radius of inner glow rounded corners
     """
     key = "InnerGlowBackground " + \
           color.name() + " " + \
@@ -413,4 +412,122 @@ def innerGlowBackgroundPixmap(color, size, radius=5):
                                    QPainter.PixmapFragmentHints(QPainter.OpaqueHint))
     outPainter.end()
 
+    QPixmapCache.insert(key, outPix)
+
     return outPix
+
+
+def shadowTemplatePixmap(color, length):
+    """
+    Returns 1 pixel wide, `length` pixels long linear-gradient.
+
+    Args:
+        color (QColor): shadow color
+        length (int): length of cast shadow
+
+    """
+    key = "InnerShadowTemplate " + \
+          color.name() + " " + \
+          str(length)
+
+    # get cached template
+    shadowPixmap = QPixmapCache.find(key)
+    if shadowPixmap:
+        return shadowPixmap
+
+    shadowPixmap = QPixmap(1, length)
+    shadowPixmap.fill(Qt.transparent)
+
+    grad = QLinearGradient(0, 0, 0, length)
+    grad.setColorAt(0, color)
+    grad.setColorAt(1, Qt.transparent)
+
+    painter = QPainter()
+    painter.begin(shadowPixmap)
+    painter.fillRect(shadowPixmap.rect(), grad)
+    painter.end()
+
+    # cache template
+    QPixmapCache.insert(key, shadowPixmap)
+
+    return shadowPixmap
+
+
+def innerShadowPixmap(color, size, pos, length=5):
+    """
+    Args:
+        color (QColor): shadow color
+        size (QSize): size of pixmap
+        pos (int): shadow position int flag, use bitwise operations
+            1 - top
+            2 - right
+            4 - bottom
+            8 - left
+        length (int): length of cast shadow
+    """
+    key = "InnerShadow " + \
+          color.name() + " " + \
+          str(size) + " " + \
+          str(pos) + " " + \
+          str(length)
+    # get cached shadow if it exists
+    finalShadow = QPixmapCache.find(key)
+    if finalShadow:
+        return finalShadow
+
+    # get shadow template pixmap (1-pixel linear gradient line)
+    shadowTemplate = QPixmapCache.find("TabButtonShadowTemplate" + str(length))
+    if shadowTemplate is None:
+        shadowTemplate = shadowTemplatePixmap(color, length)
+        QPixmapCache.insert("TabButtonShadowTemplate" + str(length),
+                            shadowTemplate)
+
+    finalShadow = QPixmap(size)
+    finalShadow.fill(Qt.transparent)
+    shadowPainter = QPainter(finalShadow)
+    shadowPainter.setCompositionMode(QPainter.CompositionMode_Darken)
+
+    # top/bottom rect
+    targetRect = QRect(0, 0, size.width(), length)
+
+    # shadow on top
+    if pos & 1:
+        shadowPainter.drawPixmap(targetRect, shadowTemplate, shadowTemplate.rect())
+    # shadow on bottom
+    if pos & 4:
+        shadowPainter.save()
+
+        shadowPainter.translate(QPointF(0, size.height()))
+        shadowPainter.scale(1, -1)
+        shadowPainter.drawPixmap(targetRect, shadowTemplate, shadowTemplate.rect())
+
+        shadowPainter.restore()
+
+    # left/right rect
+    targetRect = QRect(0, 0, size.height(), shadowTemplate.rect().height())
+
+    # shadow on the right
+    if pos & 2:
+        shadowPainter.save()
+
+        shadowPainter.translate(QPointF(size.width(), 0))
+        shadowPainter.rotate(90)
+        shadowPainter.drawPixmap(targetRect, shadowTemplate, shadowTemplate.rect())
+
+        shadowPainter.restore()
+    # shadow on left
+    if pos & 8:
+        shadowPainter.save()
+
+        shadowPainter.translate(0, size.height())
+        shadowPainter.rotate(-90)
+        shadowPainter.drawPixmap(targetRect, shadowTemplate, shadowTemplate.rect())
+
+        shadowPainter.restore()
+
+    shadowPainter.end()
+
+    # cache shadow
+    QPixmapCache.insert(key, finalShadow)
+
+    return finalShadow

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -103,7 +103,7 @@ CategoryPopupMenu {
 
 CategoryPopupMenu ToolTree QTreeView::item {
 	height: 25px;
-	background: transparent;
+	border-bottom: 1px solid #e9eff2;
 }
 
 CategoryPopupMenu QTreeView::item:selected {
@@ -345,6 +345,30 @@ QuickMenu QFrame#menu-frame {
 	border: 1px solid #9CACB4;
     border-radius: 3px;
     background-color: #E9EFF2;
+}
+
+/* separating border */
+QuickMenu QTreeView::item {
+    border-bottom: 1px solid #e9eff2;
+}
+
+QuickMenu QTreeView::item:selected {
+	background: qlineargradient(
+		x1: 0, y1: 0, x2: 0, y2: 1,
+		stop: 0 #688EF6,
+		stop: 0.5 #4047f4,
+		stop: 1.0 #2D68F3
+	);
+	color: white;
+}
+/* split 'shortcut' hint item spacing */
+QuickMenu QTreeView::item:selected:first {
+    margin-right: 0px;
+    padding-right: 0px;
+}
+QuickMenu QTreeView::item:selected:last {
+    margin-left: -1px;
+    padding-left: -1px;
 }
 
 QuickMenu TabBarWidget QToolButton {

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -348,7 +348,8 @@ QuickMenu QFrame#menu-frame {
 }
 
 QuickMenu QTreeView::item {
-	border-bottom: 1px solid #e9eff2;
+    background: transparent;
+    padding-left: 1px;
 }
 
 QuickMenu QTreeView::item:selected {

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -364,14 +364,10 @@ QuickMenu QTreeView::item:selected {
 
 QuickMenu TabBarWidget QToolButton {
 	height: 25px;
-	border-bottom: 1px solid palette(dark);
 	padding-right: 5px;
 	padding-left: 5px;
-	qproperty-showMenuIndicator_: true;
-}
-
-QuickMenu TabBarWidget QToolButton#search-tab-button {
-	background-color: #9CACB4;
+	qproperty-showMenuIndicator_: false;
+	qproperty-shadowLength_: 4;
 }
 
 QuickMenu TabBarWidget QToolButton:menu-indicator {
@@ -384,13 +380,14 @@ QuickMenu TabBarWidget QToolButton:menu-indicator {
 /* Quick Menu search line edit
  */
 
-QuickMenu QLineEdit {
+QuickMenu SearchWidget {
     height: 25px;
     margin: 0px;
     padding: 0px;
     border: 1px solid #9CACB4;
     border-radius: 3px;
     background-color: white;
+    qproperty-shadowLength_: 4;
 }
 
 QuickMenu QLineEdit:focus {

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -103,7 +103,7 @@ CategoryPopupMenu {
 
 CategoryPopupMenu ToolTree QTreeView::item {
 	height: 25px;
-	border-bottom: 1px solid #e9eff2;
+	background: transparent;
 }
 
 CategoryPopupMenu QTreeView::item:selected {

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -352,13 +352,8 @@ QuickMenu QTreeView::item {
     padding-left: 1px;
 }
 
+/* background defined in _MenuItemDelegate */
 QuickMenu QTreeView::item:selected {
-	background: qlineargradient(
-		x1: 0, y1: 0, x2: 0, y2: 1,
-		stop: 0 #688EF6,
-		stop: 0.5 #4047f4,
-		stop: 1.0 #2D68F3
-	);
 	color: white;
 }
 

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -347,16 +347,6 @@ QuickMenu QFrame#menu-frame {
     background-color: #E9EFF2;
 }
 
-QuickMenu QTreeView::item {
-    background: transparent;
-    padding-left: 1px;
-}
-
-/* background defined in _MenuItemDelegate */
-QuickMenu QTreeView::item:selected {
-	color: white;
-}
-
 QuickMenu TabBarWidget QToolButton {
 	height: 25px;
 	padding-right: 5px;


### PR DESCRIPTION
I think the quick menu has potential to be prettier.

- [x] Set default background color/outline of item according to widget category
- [x] Remove empty vertical space between categories and items (below search bar)
- [x] Add shadow to category buttons
- [x] Hide search tab
- [x] Give search icon in LineEdit search tab functionality, with shadow
- [x] Draw carriage return character next to selected item
- [x] Ensure proper functioning on Windows
- [x] Ensure proper functioning on Linux
- [x] Draw disabled item text differently from enabled
- [x] Tweak colors

v1
<img width="299" alt="Screenshot 2019-06-30 at 23 23 17" src="https://user-images.githubusercontent.com/24586651/60402381-5c67c580-9b7e-11e9-923e-f5ae43dc466f.png">