### PR TITLE
[FIX] toolgrid: Fix default (style) icon size

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -285,6 +285,7 @@ class CanvasMainWindow(QMainWindow):
 
         self.quick_category = QuickCategoryToolbar()
         self.quick_category.setButtonSize(QSize(38, 30))
+        self.quick_category.setIconSize(QSize(26, 26))
         self.quick_category.actionTriggered.connect(
             self.on_quick_category_action
         )


### PR DESCRIPTION
Fixes gh-2

The change in 7059c5c5bb3fd37dee19624cb56b944ed66b62cd
broke icon size resolve w.r.t client supplied icon sizes
(it could never shrink below PM_LargeIconSize).