### PR TITLE
[FIX] Help index encoding detection

### DIFF
--- a/orangecanvas/help/tests/test_provider.py
+++ b/orangecanvas/help/tests/test_provider.py
@@ -1,0 +1,71 @@
+import base64
+import codecs
+import io
+
+import unittest
+from orangecanvas.gui.test import QCoreAppTestCase
+
+from orangecanvas.help.provider import sniff_html_charset, HtmlIndexProvider
+
+
+class TestUtils(unittest.TestCase):
+    def test_sniff_html_charset(self):
+        contents = (
+            b'<html>\n'
+            b' <header>\n'
+            b'   <meta http-equiv="Content-Type" \n'
+            b'         content="text/html; charset=cp1252" />\n'
+            b' </header>\n'
+            b'</html>'
+        )
+        self.assertEqual(sniff_html_charset(contents), "cp1252")
+        self.assertEqual(sniff_html_charset(contents[:-7]), "cp1252")
+        self.assertEqual(
+            sniff_html_charset(contents[:-7] + b'.<>>,<<.\xfe\xff<'),
+            "cp1252"
+        )
+        contents = (
+            b'<html>\n'
+            b' <header>\n'
+            b'   <meta charset="utf-8" />\n'
+            b' </header>\n'
+            b'</html>'
+        )
+        self.assertEqual(sniff_html_charset(contents), "utf-8")
+        self.assertEqual(sniff_html_charset(codecs.BOM_UTF8 + contents), "utf-8")
+
+        self.assertEqual(sniff_html_charset(b''), None)
+        self.assertEqual(sniff_html_charset(b'<html></html>'), None)
+
+        self.assertEqual(
+            sniff_html_charset(
+                codecs.BOM_UTF16_BE +"<html></html>".encode("utf-16-be")
+            ),
+            'utf-16'
+        )
+
+
+def data_url(mimetype, payload):
+    # type: (str, bytes) -> str
+    payload = base64.b64encode(payload).decode("ascii")
+    return "data:{};base64,{}".format(mimetype, payload)
+
+
+class TestHtmlIndexProvider(QCoreAppTestCase):
+    def test(self):
+        contents = (
+            b'<html>\n'
+            b' <header>\n'
+            b'   <meta charset=cp1252" />\n'
+            b' </header>\n'
+            b' <body><div id="widgets">\n'
+            b'  <ul>\n'
+            b'   <li><a href="a.html">aa</li>\n'
+            b'  </ul>\n'
+            b'  </div>\n'
+            b'</html>'
+        )
+        url = data_url("text/html", contents)
+        p = HtmlIndexProvider(url)
+        p._load_inventory(io.BytesIO(contents))
+        self.assertEqual(p.items, {"aa": "a.html"})

--- a/orangecanvas/utils/__init__.py
+++ b/orangecanvas/utils/__init__.py
@@ -1,13 +1,33 @@
+import operator
 import types
 from functools import reduce
 
 import typing
-from typing import Iterable, Set, Any, Optional, Union, Tuple
+from typing import Iterable, Set, Any, Optional, Union, Tuple, Callable
 
 from .qtcompat import toPyObject
 
+__all__ = [
+    "dotted_getattr",
+    "qualified_name",
+    "name_lookup",
+    "type_lookup",
+    "type_lookup_",
+    "asmodule",
+    "check_type",
+    "check_arg",
+    "check_subclass",
+    "unique",
+    "assocv",
+    "assocf",
+]
+
 if typing.TYPE_CHECKING:
     H = typing.TypeVar("H", bound=typing.Hashable)
+    C = typing.TypeVar("C")
+    K = typing.TypeVar("K")
+    V = typing.TypeVar("V")
+    KV = Tuple[K, V]
 
 
 def dotted_getattr(obj, name):
@@ -112,3 +132,48 @@ def unique(iterable):
         seen.add(el)
         return observed
     return (el for el in iterable if not observed(el))
+
+
+def assocv(seq, key, eq=operator.eq):
+    # type: (Iterable[KV], C, Callable[[K, C], bool]) -> Optional[KV]
+    """
+    Find and return the first pair `p` in `seq` where `eq(p[0], key) is True`
+
+    Return None if not found.
+
+    Parameters
+    ----------
+    seq: Iterable[Tuple[K, V]]
+    key: C
+    eq: Callable[[K, C], bool]
+
+    Returns
+    -------
+    pair: Optional[Tuple[K, V]]
+    """
+    for k, v in seq:
+        if eq(k, key):
+            return k, v
+    return None
+
+
+def assocf(seq, predicate):
+    # type: (Iterable[KV], Callable[[K], bool]) -> Optional[KV]
+    """
+    Find and return the first pair `p` in `seq` where `predicate(p[0]) is True`
+
+    Return None if not found.
+
+    Parameters
+    ----------
+    seq: Iterable[Tuple[K, V]]
+    predicate: Callable[[K], bool]
+
+    Returns
+    -------
+    pair: Optional[Tuple[K, V]]
+    """
+    for k, v in seq:
+        if predicate(k):
+            return k, v
+    return None

--- a/orangecanvas/utils/tests/test_utils.py
+++ b/orangecanvas/utils/tests/test_utils.py
@@ -1,0 +1,18 @@
+import unittest
+
+from .. import assocf, assocv
+
+
+class TestUtils(unittest.TestCase):
+    def test_assoc(self):
+        cases = [
+            ([], "a", None),
+            ([("a", 1)], "a",  ("a", 1)),
+            ([("a", 1)], "b",  None),
+            ([("a", 1), ("b", 2), ("b", 3)], "b", ("b", 2)),
+        ]
+        for seq, key, expected in cases:
+            res = assocf(seq, lambda k: k == key)
+            self.assertEqual(res, expected)
+            res = assocv(seq, key)
+            self.assertEqual(res, expected)


### PR DESCRIPTION
*help.provider:HtmlIndexProvider*

Try to parse the html meta charset declaration when parsing the help index. If successful use the declared charset.

Fixes gh-9

