### PR TITLE
[ENH] Allow specification of union types in input/output meta defintions

### DIFF
--- a/orangecanvas/document/editlinksdialog.py
+++ b/orangecanvas/document/editlinksdialog.py
@@ -31,6 +31,7 @@ from ..scheme import compatible_channels
 from ..registry import InputSignal, OutputSignal
 
 from ..resources import icon_loader
+from ..utils import type_str
 
 if typing.TYPE_CHECKING:
     from ..scheme import SchemeNode
@@ -42,9 +43,9 @@ class EditLinksDialog(QDialog):
     A dialog for editing links.
 
     >>> dlg = EditLinksDialog()
-    >>> dlg.setNodes(file_node, test_learners_node)
-    >>> dlg.setLinks([(file_node.output_channel("Data"),
-    ...                test_learners_node.input_channel("Data")])
+    >>> dlg.setNodes(source_node, sink_node)
+    >>> dlg.setLinks([(source_node.output_channel("Data"),
+    ...                sink_node.input_channel("Data"))])
     >>> if dlg.exec_() == EditLinksDialog.Accepted:
     ...     new_links = dlg.links()
     ...
@@ -662,7 +663,8 @@ class EditLinksNode(QGraphicsWidget):
             text_item.setHtml(text)
             text_item.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
             text_item.setToolTip(
-                escape(getattr(channel, 'description', channel.type)))
+                escape(getattr(channel, 'description', type_str(channel.type)))
+            )
 
             grid.addItem(text_item, i, label_row,
                          alignment=label_alignment)

--- a/orangecanvas/registry/base.py
+++ b/orangecanvas/registry/base.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # Registry hex version
-VERSION_HEX = 0x000104
+VERSION_HEX = 0x000105
 
 
 class WidgetRegistry(object):

--- a/orangecanvas/registry/qt.py
+++ b/orangecanvas/registry/qt.py
@@ -15,6 +15,7 @@ from AnyQt.QtGui import QStandardItemModel, QStandardItem, QColor, QBrush
 from AnyQt.QtCore import QObject, Qt
 from AnyQt.QtCore import pyqtSignal as Signal
 
+from ..utils import type_str
 from .discovery import WidgetDiscovery
 from .description import WidgetDescription, CategoryDescription
 from .base import WidgetRegistry
@@ -309,18 +310,9 @@ def tooltip_helper(desc):
 
     inputs_fmt = "<li>{name} ({class_name})</li>"
 
-    def type_str(type_name):
-        # type: (Union[str, type]) -> str
-        if isinstance(type_name, type):
-            return type_str("{0.__module__}.{0.__qualname__}".format(type_name))
-        elif type_name.startswith("builtins."):
-            return type_name[len("builtins."):]
-        else:
-            return type_name
-
     if desc.inputs:
         inputs = "".join(inputs_fmt.format(name=inp.name,
-                                           class_name=type_str(inp.type))
+                                           class_name=type_str(inp.types))
                          for inp in desc.inputs)
         tooltip.append("Inputs:<ul>{0}</ul>".format(inputs))
     else:
@@ -328,7 +320,7 @@ def tooltip_helper(desc):
 
     if desc.outputs:
         outputs = "".join(inputs_fmt.format(name=out.name,
-                                            class_name=type_str(out.type))
+                                            class_name=type_str(out.types))
                           for out in desc.outputs)
         tooltip.append("Outputs:<ul>{0}</ul>".format(outputs))
     else:

--- a/orangecanvas/registry/tests/test_base.py
+++ b/orangecanvas/registry/tests/test_base.py
@@ -5,6 +5,7 @@ import logging
 from operator import attrgetter
 
 import unittest
+from orangecanvas.registry import InputSignal, OutputSignal
 
 from ..base import WidgetRegistry
 from .. import description
@@ -97,3 +98,24 @@ class TestRegistry(unittest.TestCase):
                             for desc in [one_desc, zero_desc, sub_desc,
                                          add_desc])
                         )
+
+    def test_input_signal(self):
+        isig_1 = InputSignal("A", str, "aa", id="sig-a")
+        isig_2 = InputSignal("A", 'builtins.str', "aa", id="sig-a")
+        self.assertTupleEqual(isig_1.types, isig_2.types)
+        self.assertTupleEqual(isig_1.types, ('builtins.str',))
+        isig_1 = InputSignal("A", (str, int), "aa", id="sig-a")
+        isig_2 = InputSignal("A", ('builtins.str', "builtins.int",), "aa",
+                             id="sig-a")
+        self.assertTupleEqual(isig_1.types, isig_2.types)
+
+    def test_output_signal(self):
+        osig_1 = OutputSignal("A", str, id="sig-a")
+        osig_2 = OutputSignal("A", 'builtins.str', id="sig-a")
+        self.assertTupleEqual(osig_1.types, osig_2.types)
+        self.assertTupleEqual(osig_1.types, ('builtins.str',))
+        osig_1 = OutputSignal("A", (str, int), id="sig-a")
+        osig_2 = OutputSignal("A", ('builtins.str', "builtins.int",),
+                              id="sig-a")
+        self.assertTupleEqual(osig_1.types, osig_2.types)
+        self.assertTupleEqual(osig_1.types, ('builtins.str', "builtins.int",))

--- a/orangecanvas/scheme/node.py
+++ b/orangecanvas/scheme/node.py
@@ -94,7 +94,6 @@ class SchemeNode(QObject):
         """
         Return the input channel matching `name`. Raise a `ValueError`
         if not found.
-
         """
         for channel in self.input_channels():
             if channel.name == name:
@@ -107,7 +106,6 @@ class SchemeNode(QObject):
         """
         Return the output channel matching `name`. Raise an `ValueError`
         if not found.
-
         """
         for channel in self.output_channels():
             if channel.name == name:

--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -767,7 +767,7 @@ def can_enable_dynamic(link, value):
     """
     Can the a dynamic `link` (:class:`SchemeLink`) be enabled for`value`.
     """
-    return isinstance(value, link.sink_type())
+    return isinstance(value, link.sink_types())
 
 
 def compress_signals(signals):

--- a/orangecanvas/scheme/tests/test_links.py
+++ b/orangecanvas/scheme/tests/test_links.py
@@ -23,8 +23,8 @@ class TestSchemeLink(test.QAppTestCase):
                            add_node,
                            add_node.input_channel("left"))
 
-        self.assertTrue(link1.source_type() is int)
-        self.assertTrue(link1.sink_type() is int)
+        self.assertEqual(link1.source_types(), (int, ))
+        self.assertEqual(link1.sink_types(), (int, ))
 
         with self.assertRaises(ValueError):
             SchemeLink(add_node, "right", one_node, "$$$[")

--- a/orangecanvas/scheme/tests/test_links.py
+++ b/orangecanvas/scheme/tests/test_links.py
@@ -1,11 +1,27 @@
 """
 Tests for SchemeLink
 """
+import warnings
 
 from ...gui import test
 from ...registry.tests import small_testing_registry
 
+from ...registry.description import InputSignal, OutputSignal, Dynamic
+
 from .. import SchemeNode, SchemeLink, IncompatibleChannelTypeError
+from ..link import resolved_valid_types, _classify_connection
+
+
+class A:
+    pass
+
+
+class B(A):
+    pass
+
+
+class C:
+    pass
 
 
 class TestSchemeLink(test.QAppTestCase):
@@ -31,3 +47,51 @@ class TestSchemeLink(test.QAppTestCase):
 
         with self.assertRaises(IncompatibleChannelTypeError):
             SchemeLink(unit_node, "value", add_node, "right")
+
+    def test_utils(self):
+        with warnings.catch_warnings(record=True):
+            self.assertTupleEqual(
+                resolved_valid_types(("int", __name__ + ".NoSuchType", "str")),
+                (int, str),
+            )
+
+        source = OutputSignal("A", (A,))
+        source_d = OutputSignal("A", (A,), flags=Dynamic)
+        source_ac_d = OutputSignal("A", (A, C), flags=Dynamic)
+        source_ac = OutputSignal("A", (B, C))
+        sink_a = InputSignal("A", (A,), "a")
+        sink_b = InputSignal("B", (B,), "b")
+        sink_c = InputSignal("C", (C,), "c")
+        sink_bc = InputSignal("C", (B, C,), "c")
+
+        t1, t2 = _classify_connection(source, sink_a)
+        self.assertTrue(t1)
+        self.assertFalse(t2)
+
+        t1, t2 = _classify_connection(source, sink_b)
+        self.assertFalse(t1)
+        self.assertFalse(t2)
+
+        t1, t2 = _classify_connection(source_d, sink_b)
+        self.assertFalse(t1)
+        self.assertTrue(t2)
+
+        t1, t2 = _classify_connection(source_d, sink_a)
+        self.assertTrue(t1)
+        self.assertTrue(t2)
+
+        t1, t2 = _classify_connection(source_d, sink_c)
+        self.assertFalse(t1)
+        self.assertFalse(t2)
+
+        t1, t2 = _classify_connection(source_d, sink_bc)
+        self.assertFalse(t1)
+        self.assertTrue(t2)
+
+        t1, t2 = _classify_connection(source_ac_d, sink_bc)
+        self.assertFalse(t1)
+        self.assertTrue(t2)
+
+        t1, t2 = _classify_connection(source_ac, sink_bc)
+        self.assertTrue(t1)
+        self.assertFalse(t2)

--- a/orangecanvas/utils/__init__.py
+++ b/orangecanvas/utils/__init__.py
@@ -49,6 +49,16 @@ def qualified_name(obj):
         return "%s.%s" % (obj.__module__, obj.__name__)
 
 
+def type_str(type_name):
+    # type: (Union[str, Tuple[str, ...]]) -> str
+    if isinstance(type_name, tuple):
+        return "Union[" + ", ".join(type_str(t) for t in type_name) + "]"
+    elif type_name.startswith("builtin."):
+        return type_name[len("builtin."):]
+    else:
+        return type_name
+
+
 def name_lookup(qualified_name):
     # type: (str) -> Any
     """
@@ -63,12 +73,29 @@ def name_lookup(qualified_name):
 
 
 def type_lookup(qualified_name):
-    # type: (str) -> Optional[type]
-    T = name_lookup(qualified_name)
-    if isinstance(T, type):
-        return T
-    else:
-        return None
+    # type: (str) -> type
+    """
+    Return the type referenced by a qualified name.
+
+    Parameters
+    ----------
+    qualified_name : str
+
+    Returns
+    -------
+    type: type
+
+    Raises
+    ------
+    TypeError:
+        If the object referenced by `qualified_name` is not a type
+    """
+    rval = name_lookup(qualified_name)
+    if not isinstance(rval, type):
+        raise TypeError(
+            "'{}' is a {!r} not a type".format(qualified_name, type(rval))
+        )
+    return rval
 
 
 def type_lookup_(tspec):


### PR DESCRIPTION
Allow the specification of union types by generalizing the the single type spec in the Input/OutputSignal to a tuple of types.

Ref: https://github.com/biolab/orange3/pull/3545#issuecomment-456373380

A strict connection type checks if all the source types are subtypes of the sink types.

A dynamic connection type checks if at least one of the sink types is a subtype of one of the source types.