### PR TITLE
[FIX] Fix styling and size hinting issues

### DIFF
--- a/orangecanvas/application/welcomedialog.py
+++ b/orangecanvas/application/welcomedialog.py
@@ -8,7 +8,7 @@ from xml.sax.saxutils import escape
 
 from AnyQt.QtWidgets import (
     QDialog, QWidget, QToolButton, QCheckBox, QAction,
-    QHBoxLayout, QVBoxLayout, QSizePolicy, QLabel
+    QHBoxLayout, QVBoxLayout, QSizePolicy, QLabel, QApplication
 )
 from AnyQt.QtGui import (
     QFont, QIcon, QPixmap, QPainter, QColor, QBrush, QActionEvent
@@ -53,8 +53,8 @@ def decorate_welcome_icon(icon, background_color):
 WELCOME_WIDGET_BUTTON_STYLE = """
 WelcomeActionButton {
     border: none;
+    font-size: 13px;
     icon-size: 75px;
-    /*font: bold italic 14px "Helvetica";*/
 }
 
 WelcomeActionButton:pressed {
@@ -72,6 +72,10 @@ WelcomeActionButton:focus {
 
 
 class WelcomeActionButton(QToolButton):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setFont(QApplication.font("QAbstractButton"))
+
     def actionEvent(self, event):
         # type: (QActionEvent) -> None
         super().actionEvent(event)

--- a/orangecanvas/application/welcomedialog.py
+++ b/orangecanvas/application/welcomedialog.py
@@ -1,6 +1,5 @@
 """
 Orange Canvas Welcome Dialog
-
 """
 from typing import Optional, Union, Iterable
 
@@ -52,21 +51,17 @@ def decorate_welcome_icon(icon, background_color):
 
 WELCOME_WIDGET_BUTTON_STYLE = """
 WelcomeActionButton {
-    border: none;
+    border: 1px solid transparent;
+    border-radius: 10px;
     font-size: 13px;
     icon-size: 75px;
 }
-
 WelcomeActionButton:pressed {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                      stop: 0 #dadbde, stop: 1 #f6f7fa);
-    border-radius: 10px;
+    background-color: palette(highlight);
+    color: palette(highlighted-text);
 }
-
 WelcomeActionButton:focus {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                                      stop: 0 #dadbde, stop: 1 #f6f7fa);
-    border-radius: 10px;
+    border: 1px solid palette(highlight);
 }
 """
 

--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -719,9 +719,12 @@ class TabButton(QToolButton):
         if self.__showMenuIndicator and self.isChecked():
             opt.features |= QStyleOptionToolButton.HasMenu
         style = self.style()
-
         hint = style.sizeFromContents(QStyle.CT_ToolButton, opt,
                                       opt.iconSize, self)
+        # add extra margin; in the absence of a better alternative
+        # just use the text <-> border margin of a push button
+        margin = style.pixelMetric(QStyle.PM_ButtonMargin, None, self)
+        hint.setWidth(hint.width() + 2 * margin)
         return hint
 
 

--- a/orangecanvas/gui/toolbox.py
+++ b/orangecanvas/gui/toolbox.py
@@ -124,10 +124,10 @@ class ToolBoxTabButton(QToolButton):
         rect = opt.rect
 
         icon_area_rect = QRect(rect)
-        icon_area_rect.setRight(int(icon_area_rect.height() * 1.26))
+        icon_area_rect.setWidth(int(icon_area_rect.height() * 1.26))
 
         text_rect = QRect(rect)
-        text_rect.setLeft(icon_area_rect.right() + 10)
+        text_rect.setLeft(icon_area_rect.x() + icon_area_rect.width() + 10)
 
         # Background
 
@@ -148,8 +148,10 @@ class ToolBoxTabButton(QToolButton):
             p.drawRect(icon_area_rect)
             # Line between the icon and text
             p.setPen(pen)
-            p.drawLine(icon_area_rect.topRight(),
-                       icon_area_rect.bottomRight())
+            p.drawLine(
+                icon_area_rect.x() + icon_area_rect.width(), icon_area_rect.y(),
+                icon_area_rect.x() + icon_area_rect.width(),
+                icon_area_rect.y() + icon_area_rect.height())
 
         if opt.state & QStyle.State_HasFocus:
             # Set the focus frame pen and draw the border
@@ -166,9 +168,10 @@ class ToolBoxTabButton(QToolButton):
             if self.position == QStyleOptionToolBox.OnlyOneTab or \
                     self.position == QStyleOptionToolBox.Beginning or \
                     self.selected & QStyleOptionToolBox.PreviousIsSelected:
-                p.drawLine(rect.topLeft(), rect.topRight())
-
-            p.drawLine(rect.bottomLeft(), rect.bottomRight())
+                p.drawLine(rect.x(), rect.y(),
+                           rect.x() + rect.width(), rect.y())
+            p.drawLine(rect.x(), rect.y() + rect.height(),
+                       rect.x() + rect.width(), rect.y() + rect.height())
 
         p.restore()
 

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -373,8 +373,6 @@ QuickMenu QTreeView::item:selected:last {
 
 QuickMenu TabBarWidget QToolButton {
 	height: 25px;
-	padding-right: 5px;
-	padding-left: 5px;
 	qproperty-showMenuIndicator_: false;
 	qproperty-shadowLength_: 4;
 }


### PR DESCRIPTION
Fix some size hinting and styling/drawing issues

The background for icons in the side toolbox would *bleed* from out the bounding borders on 2x retina displays (particularly noticeable in dark styles)

Before 
<img width="156" alt="Screenshot 2019-08-08 at 17 45 02" src="https://user-images.githubusercontent.com/4716745/62760739-faf01c00-ba84-11e9-897b-4afcc08331ff.png">

After
<img width="139" alt="Screenshot 2019-08-08 at 17 44 36" src="https://user-images.githubusercontent.com/4716745/62760755-017e9380-ba85-11e9-98ba-38ccdf8bd628.png">

The default width size hinting for 'category' buttons in quick menu was to low, which was compensated for in the style orange.qss style sheet. When running without the style sheet applied the buttons are not wide enough.

<img width="260" alt="Screenshot 2019-08-08 at 17 52 16" src="https://user-images.githubusercontent.com/4716745/62761288-903fe000-ba86-11e9-8754-c48cea2651db.png">

<img width="272" alt="Screenshot 2019-08-08 at 17 51 44" src="https://user-images.githubusercontent.com/4716745/62761299-959d2a80-ba86-11e9-8c5b-d8d059038f4b.png">

