### PR TITLE
quickmenu: Add preference setting to display categories, lighten and smallen tab buttons

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -29,8 +29,6 @@ from AnyQt.QtCore import (
     QSettings, QStandardPaths, QAbstractItemModel, QT_VERSION
 )
 
-from orangecanvas.utils.overlay import NotificationOverlay
-
 try:
     from AnyQt.QtWebEngineWidgets import QWebEngineView
 except ImportError:
@@ -45,6 +43,8 @@ except ImportError:
 from AnyQt.QtCore import (
     pyqtProperty as Property, pyqtSignal as Signal
 )
+
+from orangecanvas.utils.overlay import NotificationOverlay
 
 from ..scheme import Scheme
 from ..gui.dropshadow import DropShadowFrame
@@ -63,6 +63,7 @@ from .schemeinfo import SchemeInfoDialog
 from .outputview import OutputView, TextStream
 from .settings import UserSettingsDialog, category_state
 from ..document.schemeedit import SchemeEditWidget
+from ..document.quickmenu import QuickMenu
 from ..gui.itemmodels import FilterProxyModel
 from ..registry import WidgetRegistry, WidgetDescription, CategoryDescription
 from ..registry.qt import QtWidgetRegistry
@@ -1675,7 +1676,7 @@ class CanvasMainWindow(QMainWindow):
         preferences change.
         """
         for w in QApplication.topLevelWidgets():
-            if isinstance(w, CanvasMainWindow):
+            if isinstance(w, CanvasMainWindow) or isinstance(w, QuickMenu):
                 w.update_from_settings()
 
     def open_addons(self):

--- a/orangecanvas/application/settings.py
+++ b/orangecanvas/application/settings.py
@@ -285,33 +285,39 @@ class UserSettingsDialog(QMainWindow):
         quickmenu.setLayout(QVBoxLayout())
         quickmenu.layout().setContentsMargins(0, 0, 0, 0)
 
-        cb1 = QCheckBox(self.tr("On double click"),
+        cb1 = QCheckBox(self.tr("Open on double click"),
                         toolTip=self.tr("Open quick menu on a double click "
                                         "on an empty spot in the canvas"))
 
-        cb2 = QCheckBox(self.tr("On right click"),
+        cb2 = QCheckBox(self.tr("Open on right click"),
                         toolTip=self.tr("Open quick menu on a right click "
                                         "on an empty spot in the canvas"))
 
-        cb3 = QCheckBox(self.tr("On space key press"),
-                        toolTip=self.tr("On Space key press while the mouse"
-                                        "is hovering over the canvas."))
+        cb3 = QCheckBox(self.tr("Open on space key press"),
+                        toolTip=self.tr("Open quick menu on Space key press "
+                                        "while the mouse is hovering over the canvas."))
 
-        cb4 = QCheckBox(self.tr("On any key press"),
-                        toolTip=self.tr("On any key press while the mouse"
-                                        "is hovering over the canvas."))
+        cb4 = QCheckBox(self.tr("Open on any key press"),
+                        toolTip=self.tr("Open quick menu on any key press "
+                                        "while the mouse is hovering over the canvas."))
+
+        cb5 = QCheckBox(self.tr("Show categories"),
+                        toolTip=self.tr("In addition to searching, allow filtering "
+                                        "by categories."))
 
         self.bind(cb1, "checked", "quickmenu/trigger-on-double-click")
         self.bind(cb2, "checked", "quickmenu/trigger-on-right-click")
         self.bind(cb3, "checked", "quickmenu/trigger-on-space-key")
         self.bind(cb4, "checked", "quickmenu/trigger-on-any-key")
+        self.bind(cb5, "checked", "quickmenu/show-categories")
 
         quickmenu.layout().addWidget(cb1)
         quickmenu.layout().addWidget(cb2)
         quickmenu.layout().addWidget(cb3)
         quickmenu.layout().addWidget(cb4)
+        quickmenu.layout().addWidget(cb5)
 
-        form.addRow(self.tr("Open quick menu on"), quickmenu)
+        form.addRow(self.tr("Quick menu"), quickmenu)
 
         startup = QWidget(self, objectName="startup-group")
         startup.setLayout(QVBoxLayout())

--- a/orangecanvas/config.py
+++ b/orangecanvas/config.py
@@ -408,6 +408,9 @@ spec = \
      ("quickmenu/trigger-on-any-key", bool, False,
       "Show quick menu on double click."),
 
+     ("quickmenu/show-categories", bool, False,
+      "Show categories in quick menu."),
+
      ("logging/level", int, 1, "Logging level"),
 
      ("logging/show-on-error", bool, True, "Show log window on error"),

--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -1230,6 +1230,7 @@ class QuickMenu(FramelessWindow):
 
         self.setLayout(QVBoxLayout(self))
         self.layout().setContentsMargins(6, 6, 6, 6)
+        self.layout().setSpacing(self.radius())
 
         self.__search = SearchWidget(self, objectName="search-line")
         self.__search.setPlaceholderText(

--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -521,6 +521,7 @@ class SearchWidget(LineEdit):
     def __init__(self, parent=None, **kwargs):
         # type: (Optional[QWidget], Any) -> None
         super().__init__(parent, **kwargs)
+        self.setAttribute(Qt.WA_MacShowFocusRect, 0)
 
         self.__shadowLength = 5
         self.__shadowPosition = 0

--- a/orangecanvas/gui/tooltree.py
+++ b/orangecanvas/gui/tooltree.py
@@ -45,7 +45,7 @@ class ToolTree(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         view = QTreeView(objectName="tool-tree-view")
-        # view.setUniformRowHeights(True)  # causes several seconds delay upon first menu open
+        view.setUniformRowHeights(True)
         view.setFrameStyle(QTreeView.NoFrame)
         view.setModel(self.__model)
         view.setRootIsDecorated(False)

--- a/orangecanvas/gui/utils.py
+++ b/orangecanvas/gui/utils.py
@@ -475,12 +475,7 @@ def innerShadowPixmap(color, size, pos, length=5):
     if finalShadow:
         return finalShadow
 
-    # get shadow template pixmap (1-pixel linear gradient line)
-    shadowTemplate = QPixmapCache.find("TabButtonShadowTemplate" + str(length))
-    if shadowTemplate is None:
-        shadowTemplate = shadowTemplatePixmap(color, length)
-        QPixmapCache.insert("TabButtonShadowTemplate" + str(length),
-                            shadowTemplate)
+    shadowTemplate = shadowTemplatePixmap(color, length)
 
     finalShadow = QPixmap(size)
     finalShadow.fill(Qt.transparent)

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -391,13 +391,12 @@ QuickMenu TabBarWidget QToolButton:menu-indicator {
  */
 
 QuickMenu SearchWidget {
-    height: 25px;
+    height: 26px;
     margin: 0px;
     padding: 0px;
     border: 1px solid #9CACB4;
     border-radius: 3px;
     background-color: white;
-    qproperty-shadowLength_: 3;
 }
 
 QuickMenu QLineEdit:focus {
@@ -407,13 +406,21 @@ QuickMenu QLineEdit:focus {
 
 QuickMenu QLineEdit QToolButton {
 	qproperty-flat_: false;
+    qproperty-shadowLength_: 3;
+    qproperty-shadowColor_: #454C4F;
+    qproperty-shadowPosition_: 15;
     border: 1px solid #9CACB4;
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
-    background-color: #9CACB4;
+    background-color: #8E9CA4;
     padding: 0px;
     margin: 0px;
     icon-size: 20px;
+}
+
+QuickMenu QLineEdit QToolButton[checked="true"] {
+    qproperty-shadowPosition_: 0;
+    background-color: #9CACB4;
 }
 
 /* Notifications

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -361,6 +361,7 @@ QuickMenu QTreeView::item:selected {
 	);
 	color: white;
 }
+
 /* split 'shortcut' hint item spacing */
 QuickMenu QTreeView::item:selected:first {
     margin-right: 0px;
@@ -373,8 +374,10 @@ QuickMenu QTreeView::item:selected:last {
 
 QuickMenu TabBarWidget QToolButton {
 	height: 25px;
+	width: 25px;
+	qproperty-iconSize: 20px;
 	qproperty-showMenuIndicator_: false;
-	qproperty-shadowLength_: 4;
+	qproperty-shadowLength_: 3;
 }
 
 QuickMenu TabBarWidget QToolButton:menu-indicator {
@@ -394,7 +397,7 @@ QuickMenu SearchWidget {
     border: 1px solid #9CACB4;
     border-radius: 3px;
     background-color: white;
-    qproperty-shadowLength_: 4;
+    qproperty-shadowLength_: 3;
 }
 
 QuickMenu QLineEdit:focus {
@@ -404,14 +407,13 @@ QuickMenu QLineEdit:focus {
 
 QuickMenu QLineEdit QToolButton {
 	qproperty-flat_: false;
-    height: 25px;
     border: 1px solid #9CACB4;
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
     background-color: #9CACB4;
     padding: 0px;
     margin: 0px;
-    icon-size: 23px;
+    icon-size: 20px;
 }
 
 /* Notifications

--- a/orangecanvas/styles/orange.qss
+++ b/orangecanvas/styles/orange.qss
@@ -391,7 +391,7 @@ QuickMenu TabBarWidget QToolButton:menu-indicator {
  */
 
 QuickMenu SearchWidget {
-    height: 26px;
+    height: 22px;
     margin: 0px;
     padding: 0px;
     border: 1px solid #9CACB4;
@@ -415,7 +415,7 @@ QuickMenu QLineEdit QToolButton {
     background-color: #8E9CA4;
     padding: 0px;
     margin: 0px;
-    icon-size: 20px;
+    icon-size: 18px;
 }
 
 QuickMenu QLineEdit QToolButton[checked="true"] {


### PR DESCRIPTION
Categories in the QuickMenu are hidden by default.

As per discussion in #16, buttons were made lighter. They were also made smaller, such that the menu does not get too large when many addons are installed.

Additionally, the search icon shadow was refactored, a background color change was added.