### PR TITLE
Make target area of widget extend anchor larger

### DIFF
--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -418,7 +418,8 @@ class NodeAnchorItem(GraphicsPathObject):
         stroke_path.setCapStyle(Qt.RoundCap)
 
         # Shape is wider (bigger mouse hit area - should be settable)
-        stroke_path.setWidth(12)
+        stroke_path.setWidth(25)
+        self.prepareGeometryChange()
         self.__shape = stroke_path.createStroke(path)
 
         # The full stroke
@@ -590,6 +591,12 @@ class NodeAnchorItem(GraphicsPathObject):
             return QPainterPath(self.__shape)
         else:
             return super().shape()
+
+    def boundingRect(self):
+        if self.__shape is not None:
+            return self.__shape.controlPointRect()
+        else:
+            return GraphicsPathObject.boundingRect(self)
 
     def hoverEnterEvent(self, event):
         self.shadow.setEnabled(True)


### PR DESCRIPTION
A couple of months ago, the larger target area functionality of the node anchor was (likely accidentally) removed. This has been reinstated, and the width of the area doubled.

![ezgif-4-6e7c3e4f5afd](https://user-images.githubusercontent.com/24586651/65140383-f3198500-d9fd-11e9-8d4e-86988916434f.gif)
