### PR TITLE
Addons Dialog Refactor/Cleanup

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -7,7 +7,6 @@ import os
 import logging
 import errno
 import shlex
-import subprocess
 import itertools
 import xmlrpc.client
 import json
@@ -49,6 +48,7 @@ from AnyQt.QtCore import (
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from orangecanvas.utils import unique, name_lookup
+from orangecanvas.utils.subproc import python_process, create_process
 from ..gui.utils import message_warning, message_critical as message_error
 from ..help.manager import get_dist_meta, trim, parse_meta
 
@@ -1493,50 +1493,6 @@ def run_command(command, raise_on_fail=True, **kwargs):
             raise CommandFailed(command, process.returncode, output)
 
     return process.returncode, output
-
-
-def python_process(args, script_name=None, **kwargs):
-    # type: (List[str], Optional[str], Any) -> subprocess.Popen
-    """
-    Run a `sys.executable` in a subprocess with `args`.
-    """
-    executable = sys.executable
-    if os.name == "nt" and os.path.basename(executable) == "pythonw.exe":
-        # Don't run the script with a 'gui' (detached) process.
-        dirname = os.path.dirname(executable)
-        executable = os.path.join(dirname, "python.exe")
-
-    if script_name is not None:
-        script = script_name
-    else:
-        script = executable
-
-    return create_process(
-        [script] + args,
-        executable=executable,
-        **kwargs
-    )
-
-
-def create_process(cmd, executable=None, **kwargs):
-    # type: (List[str], Optional[str], Any) -> subprocess.Popen
-    if sys.platform == 'win32':
-        # do not open a new console window for command on windows
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        kwargs["startupinfo"] = startupinfo
-
-    return subprocess.Popen(
-        cmd,
-        executable=executable,
-        cwd=None,
-        env=_env_with_proxies(),
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        bufsize=-1,
-        universal_newlines=True,
-        **kwargs
-    )
 
 
 def main(argv=None):  # noqa

--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1,5 +1,4 @@
 import types
-import tempfile
 import enum
 import sys
 import sysconfig
@@ -16,12 +15,11 @@ import typing
 
 from concurrent.futures import ThreadPoolExecutor, Future
 from collections import deque
-from contextlib import contextmanager
 from xml.sax.saxutils import escape
 
 from typing import (
     List, Dict, Any, Optional, Union, Tuple, NamedTuple, Callable, AnyStr,
-    Iterable, Iterator
+    Iterable
 )
 
 import requests
@@ -48,7 +46,8 @@ from AnyQt.QtCore import (
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from orangecanvas.utils import unique, name_lookup
-from orangecanvas.utils.subproc import python_process, create_process
+from orangecanvas.utils.shtools import python_process, create_process, \
+    temp_named_file
 from ..gui.utils import message_warning, message_critical as message_error
 from ..help.manager import get_dist_meta, trim, parse_meta
 
@@ -1346,18 +1345,6 @@ class Installer(QObject):
         else:
             self.finished.emit()
 
-
-@contextmanager
-def temp_named_file(content, encoding="utf-8", suffix=None, prefix=None):
-    # type: (str, Optional[str], Optional[str], Optional[str]) -> Iterator[str]
-    fd, name = tempfile.mkstemp(suffix, prefix, text=True)
-    file = os.fdopen(fd, mode="wt", encoding=encoding,)
-    file.write(content)
-    file.close()
-    try:
-        yield name
-    finally:
-        os.remove(name)
 
 
 class PipInstaller:

--- a/orangecanvas/help/manager.py
+++ b/orangecanvas/help/manager.py
@@ -224,7 +224,10 @@ def parse_meta(contents):
         if key in MULTIPLE_KEYS:
             meta[key] = list(str(m) for m in message.get_all(key))
         else:
-            meta[key] = str(message.get(key))
+            value = str(message.get(key))
+            if key == "Description":
+                value = trim(value)
+            meta[key] = value
 
     version = StrictVersion(meta["Metadata-Version"])  # type: ignore
 

--- a/orangecanvas/utils/markup.py
+++ b/orangecanvas/utils/markup.py
@@ -1,0 +1,104 @@
+from collections import OrderedDict
+from xml.sax.saxutils import escape
+
+from typing import Mapping, Callable
+
+import docutils.core
+
+
+def render_plain(content: str) -> str:
+    """
+    Return a html fragment for a plain pre-formatted text
+
+    Parameters
+    ----------
+    content : str
+        Plain text content
+
+    Returns
+    -------
+    html : str
+    """
+    return '<p style="white-space: pre-wrap;">' + escape(content) + "</p>"
+
+
+def render_html(content: str) -> str:
+    """
+    Return a html fragment unchanged.
+
+    Parameters
+    ----------
+    content : str
+        Html text.
+
+    Returns
+    -------
+    html : str
+    """
+    return content
+
+
+def render_markdown(content: str) -> str:
+    """
+    Return a html fragment from markdown text content
+
+    Parameters
+    ----------
+    content : str
+        A markdown formatted text
+
+    Returns
+    -------
+    html : str
+    """
+    # commonmark >= 0.8.1; but only optionally. Many other packages may pin it
+    # to <0.8 due to breaking changes.
+    try:
+        import commonmark
+    except ImportError:
+        return render_plain(content)
+    else:
+        return commonmark.commonmark(content)
+
+
+def render_rst(content: str) -> str:
+    """
+    Return a html fragment from a RST text content
+
+    Parameters
+    ----------
+    content : str
+        A RST formatted text content
+
+    Returns
+    -------
+    html : str
+    """
+    overrides = {
+        "report_level": 10,  # suppress errors from appearing in the html
+        "output-encoding": "utf-8"
+    }
+    html = docutils.core.publish_string(
+        content, writer_name="html",
+        settings_overrides=overrides
+    )
+    return html.decode("utf-8")
+
+
+ContentRenderer = OrderedDict([
+    ("text/plain", render_plain),
+    ("text/rst", render_rst),
+    ("text/x-rst", render_rst),
+    ("text/markdown", render_markdown),
+    ("text/html", render_html),
+])  # type: Mapping[str, Callable[[str], str]]
+
+
+def render_as_rich_text(content: str, content_type="text/plain") -> str:
+    # split off the parameters (not supported)
+    content_type, _, _ = content_type.partition(";")
+    renderer = ContentRenderer.get(content_type.lower(), render_plain)
+    try:
+        return renderer(content)
+    except (ImportError, ValueError):
+        return render_plain(content)

--- a/orangecanvas/utils/shtools.py
+++ b/orangecanvas/utils/shtools.py
@@ -73,9 +73,11 @@ def create_process(
     """
     if os.name == "nt":
         # do not open a new console window for command on windows.
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        kwargs.setdefault("startupinfo", startupinfo)
+        if hasattr(subprocess, "CREATE_NO_WINDOW"):
+            CREATE_NO_WINDOW = subprocess.CREATE_NO_WINDOW  # Python 3.7
+        else:
+            CREATE_NO_WINDOW = 0x08000000
+        kwargs.setdefault("creationflags", CREATE_NO_WINDOW)
 
     return subprocess.Popen(
         args,

--- a/orangecanvas/utils/shtools.py
+++ b/orangecanvas/utils/shtools.py
@@ -1,8 +1,10 @@
-from typing import List, Optional
+from typing import List, Optional, Generator
 
 import os
 import sys
+import tempfile
 import subprocess
+from contextlib import contextmanager
 
 
 def python_process(
@@ -83,3 +85,39 @@ def create_process(
         universal_newlines=universal_newlines,
         **kwargs
     )
+
+
+@contextmanager
+def temp_named_file(
+        content: str, encoding="utf-8",
+        suffix: Optional[str] = None,
+        prefix: Optional[str] = None,
+) -> Generator[str, None, None]:
+    """
+    Create a named temporary file initialized with `contents` and yield
+    its name.
+
+    Parameters
+    ----------
+    content: str
+        The contents to write into the temp file
+    encoding: str
+        Encoding
+    suffix: Optional[str]
+        Filename suffix
+    prefix: Optional[str]
+        Filename prefix
+
+    Returns
+    -------
+    context: ContextManager
+        A context manager that deletes the file on exit.
+    """
+    fd, name = tempfile.mkstemp(suffix, prefix, text=True)
+    file = os.fdopen(fd, mode="wt", encoding=encoding,)
+    file.write(content)
+    file.close()
+    try:
+        yield name
+    finally:
+        os.remove(name)

--- a/orangecanvas/utils/shtools.py
+++ b/orangecanvas/utils/shtools.py
@@ -1,0 +1,85 @@
+from typing import List, Optional
+
+import os
+import sys
+import subprocess
+
+
+def python_process(
+        args: List[str],
+        script_name: Optional[str]=None,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        **kwargs
+) -> subprocess.Popen:
+    """
+    Run a `sys.executable` in a subprocess with `args`.
+
+    Parameters
+    ----------
+    args: List[str]
+        A list of arguments for the python interpreter (e.g. `['-m', 'pip' ]`)
+    script_name : Optional[str]
+        If supplied the `script_name` replaces 'python' as the first argument
+        of `exec?` call.
+    kwargs:
+        Passed to subproces.Popen
+
+    Return
+    ------
+    process : subprocess.Popen
+
+    Examples
+    --------
+    >>> p = python_process(['--version'])
+    >>> p.communicate()[0]
+    'Python ...
+    >>> p = python_process(['-c', 'print("hello")'])
+    >>> p.communicate()[0].rstrip()
+    'hello'
+    """
+    executable = sys.executable
+    if os.name == "nt" and os.path.basename(executable) == "pythonw.exe":
+        # Don't run the script with a 'gui' (detached) process.
+        dirname = os.path.dirname(executable)
+        executable = os.path.join(dirname, "python.exe")
+
+    if script_name is not None:
+        progname = script_name
+    else:
+        progname = executable
+    return create_process(
+        [progname] + args,
+        executable=executable, stderr=stderr, stdout=stdout, **kwargs
+    )
+
+
+def create_process(
+        args: List[str],
+        executable: Optional[str] = None,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        **kwargs
+) -> subprocess.Popen:
+    """
+    Create and return a `subprocess.Popen` instance.
+
+    This is a thin wrapper around the `subprocess.Popen`. It only thing it
+    does is it ensures that a console window does not open by default on
+    Windows.
+    """
+    if os.name == "nt":
+        # do not open a new console window for command on windows.
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        kwargs.setdefault("startupinfo", startupinfo)
+
+    return subprocess.Popen(
+        args,
+        executable=executable,
+        stderr=stderr,
+        stdout=stdout,
+        universal_newlines=universal_newlines,
+        **kwargs
+    )

--- a/orangecanvas/utils/shtools.py
+++ b/orangecanvas/utils/shtools.py
@@ -92,6 +92,7 @@ def temp_named_file(
         content: str, encoding="utf-8",
         suffix: Optional[str] = None,
         prefix: Optional[str] = None,
+        dir: Optional[str] = None,
 ) -> Generator[str, None, None]:
     """
     Create a named temporary file initialized with `contents` and yield
@@ -107,13 +108,19 @@ def temp_named_file(
         Filename suffix
     prefix: Optional[str]
         Filename prefix
+    dir: Optional[str]
+        Directory where the file will be created. If None then $TEMP is used.
 
     Returns
     -------
     context: ContextManager
         A context manager that deletes the file on exit.
+
+    See Also
+    --------
+    tempfile.mkstemp
     """
-    fd, name = tempfile.mkstemp(suffix, prefix, text=True)
+    fd, name = tempfile.mkstemp(suffix, prefix, dir=dir, text=True)
     file = os.fdopen(fd, mode="wt", encoding=encoding,)
     file.write(content)
     file.close()

--- a/orangecanvas/utils/tests/test_markup.py
+++ b/orangecanvas/utils/tests/test_markup.py
@@ -1,0 +1,35 @@
+import unittest
+from orangecanvas.utils import markup
+
+
+RST = """
+Title
+-----
+
+* aaa
+* bbb
+"""
+
+MD = """
+Title
+-----
+
+* aaa
+* bbb
+"""
+
+HTML = """<h3>Title</h3><p><ul><li>aaa</li><li>bbb</li></ul></p>"""
+
+
+# This does not really test much since most of it is in 3rd party
+# implementation. Just run through the calls
+class TestMarkup(unittest.TestCase):
+    def test_markup(self):
+        c = markup.render_as_rich_text(RST, "text/x-rst",)
+        self.assertIn("<", c)
+        c = markup.render_as_rich_text(MD, "text/markdown")
+        self.assertTrue(c.startswith("<"))
+        c = markup.render_as_rich_text(HTML, "text/html")
+        self.assertTrue(c.startswith("<"))
+        c = markup.render_as_rich_text(RST, "text/plain")
+        self.assertIn("<", c)

--- a/orangecanvas/utils/tests/test_shtools.py
+++ b/orangecanvas/utils/tests/test_shtools.py
@@ -1,0 +1,11 @@
+from orangecanvas.utils.shtools import python_process
+
+import unittest
+
+
+class Test(unittest.TestCase):
+    def test_python_process(self):
+        p = python_process(["-c", "print('Hello')"])
+        out, _ = p.communicate()
+        self.assertEqual(out.strip(), "Hello")
+        self.assertEqual(p.wait(), 0)

--- a/orangecanvas/utils/tests/test_shtools.py
+++ b/orangecanvas/utils/tests/test_shtools.py
@@ -1,4 +1,6 @@
-from orangecanvas.utils.shtools import python_process
+import os
+
+from orangecanvas.utils.shtools import python_process, temp_named_file
 
 import unittest
 
@@ -9,3 +11,15 @@ class Test(unittest.TestCase):
         out, _ = p.communicate()
         self.assertEqual(out.strip(), "Hello")
         self.assertEqual(p.wait(), 0)
+
+    def test_temp_named_file(self):
+        cases = [
+            ("Hello", "utf-8"),
+            ("Hello", "utf-16"),
+        ]
+        for content, encoding in cases:
+            with temp_named_file(content, encoding=encoding) as fname:
+                with open(fname, "r", encoding=encoding) as f:
+                    c = f.read()
+                    self.assertEqual(c, content)
+            self.assertFalse(os.path.exists(fname))


### PR DESCRIPTION
Refactor and cleanup the addons dialog.

* Remove unused code.
* Move some utilities from the addons module to utils.
* Extract and reuse the text markup rendering from annotationitem to render the add-on description text (adding support for markdown (commonmark variant only)
