### PR TITLE
Add link state change events

### DIFF
--- a/docs/source/orangecanvas/scheme.events.rst
+++ b/docs/source/orangecanvas/scheme.events.rst
@@ -1,0 +1,77 @@
+.. workflow-events:
+
+============================
+Workflow Events (``events``)
+============================
+
+.. py:currentmodule:: orangecanvas.scheme.events
+
+
+.. autoclass:: orangecanvas.scheme.events.WorkflowEvent
+   :show-inheritance:
+
+   .. autoattribute:: NodeAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: NodeRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: LinkAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: LinkRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: InputLinkAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: OutputLinkAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: InputLinkRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: OutputLinkRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: NodeStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: LinkStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: InputLinkStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: OutputLinkStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: NodeActivateRequest
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: WorkflowResourceChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: AnnotationAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: AnnotationRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: AnnotationChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: ActivateParentRequest
+      :annotation: = QEvent.Type(...)
+
+
+.. autoclass:: orangecanvas.scheme.events.NodeEvent
+   :show-inheritance:
+
+   .. automethod:: node() -> SchemeNode
+
+
+.. autoclass:: orangecanvas.scheme.events.LinkEvent
+   :show-inheritance:
+
+   .. automethod:: link() -> SchemeLink
+
+
+.. autoclass:: orangecanvas.scheme.events.AnnotationEvent
+   :show-inheritance:
+
+   .. automethod:: annotation() -> BaseSchemeAnnotation
+
+
+.. autoclass:: orangecanvas.scheme.events.WorkflowEnvChanged
+   :show-inheritance:
+
+   .. automethod:: name() -> str
+   .. automethod:: oldValue() -> Any
+   .. automethod:: newValue() -> Any
+
+
+

--- a/docs/source/orangecanvas/scheme.rst
+++ b/docs/source/orangecanvas/scheme.rst
@@ -17,3 +17,4 @@ Scheme (``scheme``)
    scheme.readwrite
    scheme.widgetmanager
    scheme.signalmanager
+   scheme.events

--- a/docs/source/orangecanvas/scheme.scheme.rst
+++ b/docs/source/orangecanvas/scheme.scheme.rst
@@ -61,22 +61,3 @@ Scheme (``scheme``)
 
 .. autoclass:: DuplicatedLinkError
    :show-inheritance:
-
-
-.. currentmodule:: orangecanvas.scheme.events
-
-.. autoclass:: orangecanvas.scheme.events.WorkflowEvent
-   :show-inheritance:
-   :members:
-
-.. autoclass:: orangecanvas.scheme.events.NodeEvent
-   :show-inheritance:
-
-.. autoclass:: orangecanvas.scheme.events.LinkEvent
-   :show-inheritance:
-
-.. autoclass:: orangecanvas.scheme.events.AnnotationEvent
-   :show-inheritance:
-
-.. autoclass:: orangecanvas.scheme.events.WorkflowEnvChanged
-   :show-inheritance:

--- a/orangecanvas/scheme/events.py
+++ b/orangecanvas/scheme/events.py
@@ -43,6 +43,10 @@ class WorkflowEvent(QEvent):
     NodeStateChange = QEvent.Type(QEvent.registerEventType())
     #: Link's (runtime) state has changed
     LinkStateChange = QEvent.Type(QEvent.registerEventType())
+    #: Input link's (runtime) state has changed
+    InputLinkStateChange = QEvent.Type(QEvent.registerEventType())
+    #: Output link's (runtime) state has changed
+    OutputLinkStateChange = QEvent.Type(QEvent.registerEventType())
     #: Request for Node's runtime initialization (e.g.
     #: load required data, establish connection, ...)
     NodeInitialize = QEvent.Type(QEvent.registerEventType())

--- a/orangecanvas/scheme/events.py
+++ b/orangecanvas/scheme/events.py
@@ -1,6 +1,7 @@
 """
-Workflow Events
----------------
+============================
+Workflow Events (``events``)
+============================
 
 Here defined are events dispatched to and from an Scheme workflow
 instance.
@@ -21,38 +22,50 @@ __all__ = [
 
 
 class WorkflowEvent(QEvent):
-    #: Delivered to Scheme when a node has been added
+    #: Delivered to Scheme when a node has been added (:class:`NodeEvent`)
     NodeAdded = QEvent.Type(QEvent.registerEventType())
-    #: Delivered to Scheme when a node has been removed
+
+    #: Delivered to Scheme when a node has been removed (:class:`NodeEvent`)
     NodeRemoved = QEvent.Type(QEvent.registerEventType())
-    #: A Link has been added to the scheme
+
+    #: A Link has been added to the scheme (:class:`LinkEvent`)
     LinkAdded = QEvent.Type(QEvent.registerEventType())
-    #: A Link has been removed from the scheme
+
+    #: A Link has been removed from the scheme (:class:`LinkEvent`)
     LinkRemoved = QEvent.Type(QEvent.registerEventType())
 
-    #: An input Link has been added to a node
+    #: An input Link has been added to a node (:class:`LinkEvent`)
     InputLinkAdded = QEvent.Type(QEvent.registerEventType())
-    #: An output Link has been added to a node
+
+    #: An output Link has been added to a node (:class:`LinkEvent`)
     OutputLinkAdded = QEvent.Type(QEvent.registerEventType())
-    #: An input Link has been removed from a node
+
+    #: An input Link has been removed from a node (:class:`LinkEvent`)
     InputLinkRemoved = QEvent.Type(QEvent.registerEventType())
-    #: An output Link has been removed from a node
+
+    #: An output Link has been removed from a node (:class:`LinkEvent`)
     OutputLinkRemoved = QEvent.Type(QEvent.registerEventType())
 
-    #: Node's (runtime) state has changed
+    #: Node's (runtime) state has changed (:class:`NodeEvent`)
     NodeStateChange = QEvent.Type(QEvent.registerEventType())
-    #: Link's (runtime) state has changed
+
+    #: Link's (runtime) state has changed (:class:`LinkEvent`)
     LinkStateChange = QEvent.Type(QEvent.registerEventType())
-    #: Input link's (runtime) state has changed
+
+    #: Input link's (runtime) state has changed (:class:`LinkEvent`)
     InputLinkStateChange = QEvent.Type(QEvent.registerEventType())
-    #: Output link's (runtime) state has changed
+
+    #: Output link's (runtime) state has changed (:class:`LinkEvent`)
     OutputLinkStateChange = QEvent.Type(QEvent.registerEventType())
+
     #: Request for Node's runtime initialization (e.g.
     #: load required data, establish connection, ...)
     NodeInitialize = QEvent.Type(QEvent.registerEventType())
+
     #: Restore the node from serialized state
     NodeRestore = QEvent.Type(QEvent.registerEventType())
     NodeSaveStateRequest = QEvent.Type(QEvent.registerEventType())
+
     #: Node user activate request (e.g. on double click in the
     #: canvas GUI)
     NodeActivateRequest = QEvent.Type(QEvent.registerEventType())
@@ -77,6 +90,23 @@ class WorkflowEvent(QEvent):
 
 
 class NodeEvent(WorkflowEvent):
+    """
+    An event notifying the receiver of an workflow link change.
+
+    This event is used with:
+
+        * :data:`WorkflowEvent.NodeAdded`
+        * :data:`WorkflowEvent.NodeRemoved`
+        * :data:`WorkflowEvent.NodeStateChange`
+        * :data:`WorkflowEvent.NodeActivateRequest`
+        * :data:`WorkflowEvent.ActivateParentRequest`
+        * :data:`WorkflowEvent.OutputLinkRemoved`
+
+    Parameters
+    ----------
+    etype: QEvent.Type
+    node: SchemeNode
+    """
     def __init__(self, etype, node):
         # type: (QEvent.Type, SchemeNode) -> None
         super().__init__(etype)
@@ -94,6 +124,26 @@ class NodeEvent(WorkflowEvent):
 
 
 class LinkEvent(WorkflowEvent):
+    """
+    An event notifying the receiver of an workflow link change.
+
+    This event is used with:
+
+        * :data:`WorkflowEvent.LinkAdded`
+        * :data:`WorkflowEvent.LinkRemoved`
+        * :data:`WorkflowEvent.InputLinkAdded`
+        * :data:`WorkflowEvent.InputLinkRemoved`
+        * :data:`WorkflowEvent.OutputLinkAdded`
+        * :data:`WorkflowEvent.OutputLinkRemoved`
+        * :data:`WorkflowEvent.InputLinkStateChange`
+        * :data:`WorkflowEvent.OutputLinkStateChange`
+
+    Parameters
+    ----------
+    etype: QEvent.Type
+    link: SchemeLink
+        The link subject to change
+    """
     def __init__(self, etype, link):
         # type: (QEvent.Type, SchemeLink) -> None
         super().__init__(etype)
@@ -111,6 +161,20 @@ class LinkEvent(WorkflowEvent):
 
 
 class AnnotationEvent(WorkflowEvent):
+    """
+    An event notifying the receiver of an workflow annotation changes
+
+    This event is used with:
+
+        * :data:`WorkflowEvent.AnnotationAdded`
+        * :data:`WorkflowEvent.AnnotationRemoved`
+
+    Parameters
+    ----------
+    etype: QEvent.Type
+    annotation: BaseSchemeAnnotation
+        The annotation that is a subject of change.
+    """
     def __init__(self, etype, annotation):
         # type: (QEvent.Type, BaseSchemeAnnotation) -> None
         super().__init__(etype)
@@ -130,6 +194,15 @@ class AnnotationEvent(WorkflowEvent):
 class WorkflowEnvChanged(WorkflowEvent):
     """
     An event notifying the receiver of a workflow environment change.
+
+    Parameters
+    ----------
+    name: str
+        The name of the environment property that was changed
+    newValue: Any
+        The new value
+    oldValue: Any
+        The old value
 
     See Also
     --------

--- a/orangecanvas/scheme/link.py
+++ b/orangecanvas/scheme/link.py
@@ -10,12 +10,13 @@ import typing
 from traceback import format_exception_only
 from typing import List, Tuple, Union, Optional, Iterable
 
-from AnyQt.QtCore import QObject
+from AnyQt.QtCore import QObject, QCoreApplication
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 
 from ..registry.description import normalize_type_simple
 from ..utils import type_lookup
 from .errors import IncompatibleChannelTypeError
+from .events import LinkEvent
 
 if typing.TYPE_CHECKING:
     from ..registry import OutputSignal as Output, InputSignal as Input
@@ -349,6 +350,10 @@ class SchemeLink(QObject):
         """
         if self.__state != state:
             self.__state = state
+            ev = LinkEvent(LinkEvent.InputLinkStateChange, self)
+            QCoreApplication.sendEvent(self.sink_node, ev)
+            ev = LinkEvent(LinkEvent.OutputLinkStateChange, self)
+            QCoreApplication.sendEvent(self.source_node, ev)
             self.state_changed.emit(state)
 
     def runtime_state(self):

--- a/orangecanvas/scheme/tests/test_widgetmanager.py
+++ b/orangecanvas/scheme/tests/test_widgetmanager.py
@@ -5,7 +5,7 @@ import unittest
 from AnyQt.QtWidgets import QWidget, QApplication, QAction
 from AnyQt.QtTest import QSignalSpy
 
-from orangecanvas.scheme import Scheme, NodeEvent
+from orangecanvas.scheme import Scheme, NodeEvent, SchemeLink, LinkEvent
 from orangecanvas.scheme.widgetmanager import WidgetManager
 from orangecanvas.registry import tests as registry_tests
 from orangecanvas.scheme.tests import EventSpy
@@ -167,6 +167,11 @@ class TestWidgetManager(unittest.TestCase):
         w1._evt.clear()
         workflow.set_runtime_env("tt", "aaa")
         self.assertIn(NodeEvent.WorkflowEnvironmentChange, w1._evt)
+
+        w3._evt.clear()
+        l1.set_runtime_state(SchemeLink.Pending)
+        self.assertIn(LinkEvent.InputLinkStateChange, w3._evt)
+        self.assertIn(LinkEvent.OutputLinkStateChange, w1._evt)
 
     def test_actions(self):
         workflow = self.scheme

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -53,12 +53,16 @@ class WidgetManager(QObject):
     The widgets created with :func:`create_widget_for_node` will automatically
     receive dispatched events:
 
-        * :data:`WorkflowEvent.InputLinkAdded` - when a new input link is added to
-          the workflow.
-        * :data:`LinkEvent.InputLinkRemoved` - when a input link is removed
-        * :data:`LinkEvent.OutputLinkAdded` - when a new output link is added to
-          the workflow
-        * :data:`LinkEvent.InputLinkRemoved` - when a output link is removed
+        * :data:`WorkflowEvent.InputLinkAdded` - when a new input link is
+          added to the workflow.
+        * :data:`LinkEvent.InputLinkRemoved` - when a input link is removed.
+        * :data:`LinkEvent.OutputLinkAdded` - when a new output link is
+          added to the workflow.
+        * :data:`LinkEvent.InputLinkRemoved` - when a output link is removed.
+        * :data:`LinkEvent.InputLinkStateChanged` - when the input link's
+          runtime state changes.
+        * :data:`LinkEvent.OutputLinkStateChanged` - when the output link's
+          runtime state changes.
         * :data:`WorkflowEnvEvent.WorkflowEnvironmentChanged` - when the
           workflow environment changes.
 
@@ -587,9 +591,17 @@ class WidgetManager(QObject):
 
     def eventFilter(self, recv, event):
         # type: (QObject, QEvent) -> bool
-        if event.type() == NodeEvent.NodeActivateRequest \
-                and isinstance(recv, SchemeNode):
-            self.__activate_widget_for_node(recv)
+        if isinstance(recv, SchemeNode):
+            if event.type() == NodeEvent.NodeActivateRequest:
+                self.__activate_widget_for_node(recv)
+            elif event.type() in (
+                    LinkEvent.InputLinkStateChange,
+                    LinkEvent.OutputLinkStateChange,
+            ):
+                item = self.__item_for_node.get(recv)
+                # dispatch the event to the gui widget
+                if item is not None and item.widget is not None:
+                    QCoreApplication.sendEvent(item.widget, event)
         return False
 
     def __set_float_on_top_flag(self, widget):


### PR DESCRIPTION
Add (Input|Output)LinkStateChange events (on link runtime change dispatched to the source sink node).

In widgetmanager re-dispatch the events to the gui widget.

