### PR TITLE
Install with conda setting checked by default

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1382,8 +1382,8 @@ class PipInstaller:
 
 class CondaInstaller:
     def __init__(self):
-        enabled = QSettings().value('add-ons/allow-conda-experimental',
-                                    False, type=bool)
+        enabled = QSettings().value('add-ons/allow-conda',
+                                    True, type=bool)
         if enabled:
             self.conda = self._find_conda()
         else:

--- a/orangecanvas/application/settings.py
+++ b/orangecanvas/application/settings.py
@@ -426,8 +426,8 @@ class UserSettingsDialog(QMainWindow):
         conda.layout().setContentsMargins(0, 0, 0, 0)
 
         cb_conda_install = QCheckBox(self.tr("Install add-ons with conda"), self,
-                                     objectName="allow-conda-experimental")
-        self.bind(cb_conda_install, "checked", "add-ons/allow-conda-experimental")
+                                     objectName="allow-conda")
+        self.bind(cb_conda_install, "checked", "add-ons/allow-conda")
         conda.layout().addWidget(cb_conda_install)
 
         form.addRow(self.tr("Conda"), conda)

--- a/orangecanvas/application/tests/test_settings.py
+++ b/orangecanvas/application/tests/test_settings.py
@@ -2,10 +2,12 @@ import logging
 
 from AnyQt.QtCore import QSettings
 from AnyQt.QtWidgets import QTreeView
+from orangecanvas import config
 
 from ...gui import test
 
-from ..settings import UserSettingsDialog, UserSettingsModel
+from ..settings import UserSettingsDialog, UserSettingsModel, \
+    UserDefaultsPropertyBinding
 from ...utils.settings import Settings, config_slot
 from ... import registry
 from ...registry import tests as registry_tests
@@ -44,3 +46,14 @@ class TestUserSettings(test.QAppTestCase):
 
         view.show()
         self.app.exec_()
+
+    def test_conda_checkbox(self):
+        """
+        We want that orange is installed with conda by default, users can
+        change this setting in settings if they need to. This test check
+        whether the default setting for conda checkbox is True.
+        """
+        settings = config.settings()
+        setting = UserDefaultsPropertyBinding(
+            settings, "add-ons/allow-conda")
+        self.assertTrue(setting.get())

--- a/orangecanvas/config.py
+++ b/orangecanvas/config.py
@@ -420,7 +420,7 @@ spec = \
      ("help/open-in-external-browser", bool, False,
       "Open help in an external browser"),
 
-     ("add-ons/allow-conda-experimental", bool, False,
+     ("add-ons/allow-conda", bool, True,
       "Install add-ons with conda"),
 
      ("add-ons/pip-install-arguments", str, '',


### PR DESCRIPTION
#### Issue

`Install with conda` setting is not checked by default in Orange. We want that packages are installed with conda by default since especially Windows users have issues to install packages that need to be compiled when installing from pip. 

#### Changes

`Install with conda` setting is now checked by default in Orange.