### PR TITLE
Short names for widgets whose name elides in toolbox

### DIFF
--- a/orangecanvas/gui/toolgrid.py
+++ b/orangecanvas/gui/toolgrid.py
@@ -17,6 +17,8 @@ from AnyQt.QtGui import (
 from AnyQt.QtCore import Qt, QObject, QSize, QEvent, QSignalMapper
 from AnyQt.QtCore import Signal, Slot
 
+from orangecanvas.registry import WidgetDescription
+
 __all__ = [
     "ToolGrid"
 ]
@@ -67,6 +69,10 @@ class ToolGridButton(QToolButton):
     def __textLayout(self):
         # type:  () -> None
         fm = self.fontMetrics()
+        desc = self.defaultAction().data()
+        if isinstance(desc, WidgetDescription) and desc.short_name:
+            self.__text = desc.short_name
+            return
         text = self.defaultAction().text()
         words = deque(text.split())
 
@@ -97,7 +103,6 @@ class ToolGridButton(QToolButton):
                     # Warning: hardcoded max lines
                     curr_line = fm.elidedText(line_extended, Qt.ElideRight,
                                               width)
-                    curr_line = curr_line
                 else:
                     # Put the word back
                     words.appendleft(w)

--- a/orangecanvas/registry/description.py
+++ b/orangecanvas/registry/description.py
@@ -341,10 +341,13 @@ class WidgetDescription(object):
         Widget's background color (in the canvas GUI).
     replaces : list of `str`, optional
         A list of ids this widget replaces (optional).
+    short_name: str, optional
+        Short name for display where text would otherwise elide.
     """
     name = ""  # type: str
     id = ""    # type: str
     qualified_name = None  # type: str
+    short_name = None  # type: str
 
     description = ""  # type: str
     category = None      # type: Optional[str]
@@ -365,7 +368,7 @@ class WidgetDescription(object):
                  help=None, help_ref=None, url=None, keywords=None,
                  priority=sys.maxsize,
                  icon=None, background=None,
-                 replaces=None,
+                 replaces=None, short_name=None,
                  ):
 
         if not qualified_name:
@@ -381,6 +384,7 @@ class WidgetDescription(object):
         self.qualified_name = qualified_name
         self.package = package
         self.project_name = project_name
+        self.short_name = short_name
         # Copy input/outputs and normalize the type to string.
         inputs = [
             InputSignal(


### PR DESCRIPTION
##### Description of changes
In an effort to avoid eliding text in the toolbox, a `short_name` property was added to widgets and `WidgetDescription`, which overrides the text in the toolbox.