### PR TITLE
Prettify the tool tip when the type union has a single member

### DIFF
--- a/orangecanvas/utils/__init__.py
+++ b/orangecanvas/utils/__init__.py
@@ -52,7 +52,10 @@ def qualified_name(obj):
 def type_str(type_name):
     # type: (Union[str, Tuple[str, ...]]) -> str
     if isinstance(type_name, tuple):
-        return "Union[" + ", ".join(type_str(t) for t in type_name) + "]"
+        if len(type_name) == 1:
+            return type_str(type_name[0])
+        else:
+            return "Union[" + ", ".join(type_str(t) for t in type_name) + "]"
     elif type_name.startswith("builtin."):
         return type_name[len("builtin."):]
     else:


### PR DESCRIPTION
Since gh-11 the I/O tooltips in the toolbox contain 'Union[...]' for all items (even when the I/O has a single has a single type member).

<img width="349" alt="Screenshot 2019-09-26 at 11 26 08" src="https://user-images.githubusercontent.com/4716745/65676604-7cf5cd80-e050-11e9-9744-0c6aa3c942f9.png">

Simplify the type string for a single union member.