### PR TITLE
SignalManager: Add support for output invalidation

### DIFF
--- a/docs/source/orangecanvas/scheme.events.rst
+++ b/docs/source/orangecanvas/scheme.events.rst
@@ -1,0 +1,77 @@
+.. workflow-events:
+
+============================
+Workflow Events (``events``)
+============================
+
+.. py:currentmodule:: orangecanvas.scheme.events
+
+
+.. autoclass:: orangecanvas.scheme.events.WorkflowEvent
+   :show-inheritance:
+
+   .. autoattribute:: NodeAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: NodeRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: LinkAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: LinkRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: InputLinkAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: OutputLinkAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: InputLinkRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: OutputLinkRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: NodeStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: LinkStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: InputLinkStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: OutputLinkStateChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: NodeActivateRequest
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: WorkflowResourceChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: AnnotationAdded
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: AnnotationRemoved
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: AnnotationChange
+      :annotation: = QEvent.Type(...)
+   .. autoattribute:: ActivateParentRequest
+      :annotation: = QEvent.Type(...)
+
+
+.. autoclass:: orangecanvas.scheme.events.NodeEvent
+   :show-inheritance:
+
+   .. automethod:: node() -> SchemeNode
+
+
+.. autoclass:: orangecanvas.scheme.events.LinkEvent
+   :show-inheritance:
+
+   .. automethod:: link() -> SchemeLink
+
+
+.. autoclass:: orangecanvas.scheme.events.AnnotationEvent
+   :show-inheritance:
+
+   .. automethod:: annotation() -> BaseSchemeAnnotation
+
+
+.. autoclass:: orangecanvas.scheme.events.WorkflowEnvChanged
+   :show-inheritance:
+
+   .. automethod:: name() -> str
+   .. automethod:: oldValue() -> Any
+   .. automethod:: newValue() -> Any
+
+
+

--- a/docs/source/orangecanvas/scheme.node.rst
+++ b/docs/source/orangecanvas/scheme.node.rst
@@ -24,3 +24,6 @@ Scheme Node (``node``)
    .. autoattribute:: progress_changed(progress)
 
    .. autoattribute:: processing_state_changed(state)
+
+.. autoclass:: orangecanvas.scheme.node::SchemeNode.State
+   :members:

--- a/docs/source/orangecanvas/scheme.rst
+++ b/docs/source/orangecanvas/scheme.rst
@@ -17,3 +17,4 @@ Scheme (``scheme``)
    scheme.readwrite
    scheme.widgetmanager
    scheme.signalmanager
+   scheme.events

--- a/docs/source/orangecanvas/scheme.scheme.rst
+++ b/docs/source/orangecanvas/scheme.scheme.rst
@@ -61,22 +61,3 @@ Scheme (``scheme``)
 
 .. autoclass:: DuplicatedLinkError
    :show-inheritance:
-
-
-.. currentmodule:: orangecanvas.scheme.events
-
-.. autoclass:: orangecanvas.scheme.events.WorkflowEvent
-   :show-inheritance:
-   :members:
-
-.. autoclass:: orangecanvas.scheme.events.NodeEvent
-   :show-inheritance:
-
-.. autoclass:: orangecanvas.scheme.events.LinkEvent
-   :show-inheritance:
-
-.. autoclass:: orangecanvas.scheme.events.AnnotationEvent
-   :show-inheritance:
-
-.. autoclass:: orangecanvas.scheme.events.WorkflowEnvChanged
-   :show-inheritance:

--- a/orangecanvas/canvas/items/linkitem.py
+++ b/orangecanvas/canvas/items/linkitem.py
@@ -321,6 +321,8 @@ class LinkItem(QGraphicsWidget):
     Active = SchemeLink.Active
     #: The link is pending; the sink node is scheduled for update
     Pending = SchemeLink.Pending
+    #: The link's input is marked as invalidated (not yet available).
+    Invalidated = SchemeLink.Invalidated
 
     def __init__(self, parent=None, **kwargs):
         # type: (Optional[QGraphicsItem], Any) -> None
@@ -724,6 +726,10 @@ class LinkItem(QGraphicsWidget):
                 self.sinkAnchor.setBrush(QBrush(Qt.red))
             else:
                 self.sinkAnchor.setBrush(QBrush(QColor("#9CACB4")))
+            if state & LinkItem.Invalidated:
+                self.sourceAnchor.setBrush(QBrush(Qt.red))
+            else:
+                self.sourceAnchor.setBrush(QBrush(QColor("#9CACB4")))
             self.__updatePen()
 
     def runtimeState(self):

--- a/orangecanvas/registry/description.py
+++ b/orangecanvas/registry/description.py
@@ -353,8 +353,8 @@ class WidgetDescription(object):
     category = None      # type: Optional[str]
     project_name = None  # type: Optional[str]
 
-    inputs = []  # type: List[InputSignal]
-    output = []  # type: List[OutputSignal]
+    inputs = []   # type: List[InputSignal]
+    outputs = []  # type: List[OutputSignal]
 
     replaces = []  # type: List[str]
     keywords = []  # type: List[str]

--- a/orangecanvas/scheme/__init__.py
+++ b/orangecanvas/scheme/__init__.py
@@ -23,3 +23,16 @@ from .annotations import (
 
 from .errors import *
 from .events import *
+
+#: Alias for SchemeNode
+Node = SchemeNode
+#: Alias for SchemeLink
+Link = SchemeLink
+#: Alias for Scheme
+Workflow = Scheme
+#: Alias for BaseSchemeAnnotation
+Annotation = BaseSchemeAnnotation
+#: Alias for SchemeArrowAnnotation
+Arrow = SchemeArrowAnnotation
+#: Alias for SchemeTextAnnotation
+Text = SchemeTextAnnotation

--- a/orangecanvas/scheme/events.py
+++ b/orangecanvas/scheme/events.py
@@ -43,6 +43,10 @@ class WorkflowEvent(QEvent):
     NodeStateChange = QEvent.Type(QEvent.registerEventType())
     #: Link's (runtime) state has changed
     LinkStateChange = QEvent.Type(QEvent.registerEventType())
+    #: Input link's (runtime) state has changed
+    InputLinkStateChange = QEvent.Type(QEvent.registerEventType())
+    #: Output link's (runtime) state has changed
+    OutputLinkStateChange = QEvent.Type(QEvent.registerEventType())
     #: Request for Node's runtime initialization (e.g.
     #: load required data, establish connection, ...)
     NodeInitialize = QEvent.Type(QEvent.registerEventType())

--- a/orangecanvas/scheme/events.py
+++ b/orangecanvas/scheme/events.py
@@ -1,6 +1,7 @@
 """
-Workflow Events
----------------
+============================
+Workflow Events (``events``)
+============================
 
 Here defined are events dispatched to and from an Scheme workflow
 instance.
@@ -21,38 +22,50 @@ __all__ = [
 
 
 class WorkflowEvent(QEvent):
-    #: Delivered to Scheme when a node has been added
+    #: Delivered to Scheme when a node has been added (:class:`NodeEvent`)
     NodeAdded = QEvent.Type(QEvent.registerEventType())
-    #: Delivered to Scheme when a node has been removed
+
+    #: Delivered to Scheme when a node has been removed (:class:`NodeEvent`)
     NodeRemoved = QEvent.Type(QEvent.registerEventType())
-    #: A Link has been added to the scheme
+
+    #: A Link has been added to the scheme (:class:`LinkEvent`)
     LinkAdded = QEvent.Type(QEvent.registerEventType())
-    #: A Link has been removed from the scheme
+
+    #: A Link has been removed from the scheme (:class:`LinkEvent`)
     LinkRemoved = QEvent.Type(QEvent.registerEventType())
 
-    #: An input Link has been added to a node
+    #: An input Link has been added to a node (:class:`LinkEvent`)
     InputLinkAdded = QEvent.Type(QEvent.registerEventType())
-    #: An output Link has been added to a node
+
+    #: An output Link has been added to a node (:class:`LinkEvent`)
     OutputLinkAdded = QEvent.Type(QEvent.registerEventType())
-    #: An input Link has been removed from a node
+
+    #: An input Link has been removed from a node (:class:`LinkEvent`)
     InputLinkRemoved = QEvent.Type(QEvent.registerEventType())
-    #: An output Link has been removed from a node
+
+    #: An output Link has been removed from a node (:class:`LinkEvent`)
     OutputLinkRemoved = QEvent.Type(QEvent.registerEventType())
 
-    #: Node's (runtime) state has changed
+    #: Node's (runtime) state has changed (:class:`NodeEvent`)
     NodeStateChange = QEvent.Type(QEvent.registerEventType())
-    #: Link's (runtime) state has changed
+
+    #: Link's (runtime) state has changed (:class:`LinkEvent`)
     LinkStateChange = QEvent.Type(QEvent.registerEventType())
-    #: Input link's (runtime) state has changed
+
+    #: Input link's (runtime) state has changed (:class:`LinkEvent`)
     InputLinkStateChange = QEvent.Type(QEvent.registerEventType())
-    #: Output link's (runtime) state has changed
+
+    #: Output link's (runtime) state has changed (:class:`LinkEvent`)
     OutputLinkStateChange = QEvent.Type(QEvent.registerEventType())
+
     #: Request for Node's runtime initialization (e.g.
     #: load required data, establish connection, ...)
     NodeInitialize = QEvent.Type(QEvent.registerEventType())
+
     #: Restore the node from serialized state
     NodeRestore = QEvent.Type(QEvent.registerEventType())
     NodeSaveStateRequest = QEvent.Type(QEvent.registerEventType())
+
     #: Node user activate request (e.g. on double click in the
     #: canvas GUI)
     NodeActivateRequest = QEvent.Type(QEvent.registerEventType())
@@ -77,6 +90,23 @@ class WorkflowEvent(QEvent):
 
 
 class NodeEvent(WorkflowEvent):
+    """
+    An event notifying the receiver of an workflow link change.
+
+    This event is used with:
+
+        * :data:`WorkflowEvent.NodeAdded`
+        * :data:`WorkflowEvent.NodeRemoved`
+        * :data:`WorkflowEvent.NodeStateChange`
+        * :data:`WorkflowEvent.NodeActivateRequest`
+        * :data:`WorkflowEvent.ActivateParentRequest`
+        * :data:`WorkflowEvent.OutputLinkRemoved`
+
+    Parameters
+    ----------
+    etype: QEvent.Type
+    node: SchemeNode
+    """
     def __init__(self, etype, node):
         # type: (QEvent.Type, SchemeNode) -> None
         super().__init__(etype)
@@ -94,6 +124,26 @@ class NodeEvent(WorkflowEvent):
 
 
 class LinkEvent(WorkflowEvent):
+    """
+    An event notifying the receiver of an workflow link change.
+
+    This event is used with:
+
+        * :data:`WorkflowEvent.LinkAdded`
+        * :data:`WorkflowEvent.LinkRemoved`
+        * :data:`WorkflowEvent.InputLinkAdded`
+        * :data:`WorkflowEvent.InputLinkRemoved`
+        * :data:`WorkflowEvent.OutputLinkAdded`
+        * :data:`WorkflowEvent.OutputLinkRemoved`
+        * :data:`WorkflowEvent.InputLinkStateChange`
+        * :data:`WorkflowEvent.OutputLinkStateChange`
+
+    Parameters
+    ----------
+    etype: QEvent.Type
+    link: SchemeLink
+        The link subject to change
+    """
     def __init__(self, etype, link):
         # type: (QEvent.Type, SchemeLink) -> None
         super().__init__(etype)
@@ -111,6 +161,20 @@ class LinkEvent(WorkflowEvent):
 
 
 class AnnotationEvent(WorkflowEvent):
+    """
+    An event notifying the receiver of an workflow annotation changes
+
+    This event is used with:
+
+        * :data:`WorkflowEvent.AnnotationAdded`
+        * :data:`WorkflowEvent.AnnotationRemoved`
+
+    Parameters
+    ----------
+    etype: QEvent.Type
+    annotation: BaseSchemeAnnotation
+        The annotation that is a subject of change.
+    """
     def __init__(self, etype, annotation):
         # type: (QEvent.Type, BaseSchemeAnnotation) -> None
         super().__init__(etype)
@@ -130,6 +194,15 @@ class AnnotationEvent(WorkflowEvent):
 class WorkflowEnvChanged(WorkflowEvent):
     """
     An event notifying the receiver of a workflow environment change.
+
+    Parameters
+    ----------
+    name: str
+        The name of the environment property that was changed
+    newValue: Any
+        The new value
+    oldValue: Any
+        The old value
 
     See Also
     --------

--- a/orangecanvas/scheme/link.py
+++ b/orangecanvas/scheme/link.py
@@ -10,12 +10,13 @@ import typing
 from traceback import format_exception_only
 from typing import List, Tuple, Union, Optional, Iterable
 
-from AnyQt.QtCore import QObject
+from AnyQt.QtCore import QObject, QCoreApplication
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 
 from ..registry.description import normalize_type_simple
 from ..utils import type_lookup
 from .errors import IncompatibleChannelTypeError
+from .events import LinkEvent
 
 if typing.TYPE_CHECKING:
     from ..registry import OutputSignal as Output, InputSignal as Input
@@ -349,6 +350,10 @@ class SchemeLink(QObject):
         """
         if self.__state != state:
             self.__state = state
+            ev = LinkEvent(LinkEvent.InputLinkStateChange, self)
+            QCoreApplication.sendEvent(self.sink_node, ev)
+            ev = LinkEvent(LinkEvent.OutputLinkStateChange, self)
+            QCoreApplication.sendEvent(self.source_node, ev)
             self.state_changed.emit(state)
 
     def runtime_state(self):

--- a/orangecanvas/scheme/link.py
+++ b/orangecanvas/scheme/link.py
@@ -245,7 +245,7 @@ class SchemeLink(QObject):
 
         self.__enabled = enabled
         self.__dynamic_enabled = False
-        self.__state = SchemeLink.NoState
+        self.__state = SchemeLink.NoState  # type: Union[SchemeLink.State, int]
         self.__tool_tip = ""
         self.properties = properties or {}
 
@@ -346,7 +346,7 @@ class SchemeLink(QObject):
                                fset=set_dynamic_enabled)
 
     def set_runtime_state(self, state):
-        # type: (State) -> None
+        # type: (Union[State, int]) -> None
         """
         Set the link's runtime state.
 
@@ -363,7 +363,7 @@ class SchemeLink(QObject):
             self.state_changed.emit(state)
 
     def runtime_state(self):
-        # type: () -> State
+        # type: () -> Union[State, int]
         """
         Returns
         -------

--- a/orangecanvas/scheme/link.py
+++ b/orangecanvas/scheme/link.py
@@ -200,11 +200,17 @@ class SchemeLink(QObject):
         #: A link is pending when it's sink node has not yet been notified
         #: of a change (note that Empty|Pending is a valid state)
         Pending = 4
+        #: The link's source has been is invalidated. Until this flag is
+        #: cleared no dependent nodes will receive new signals.
+        #:
+        #: .. versionadded:: 0.1.8
+        Invalidated = 8
 
     NoState = State.NoState
     Empty = State.Empty
     Active = State.Active
     Pending = State.Pending
+    Invalidated = State.Invalidated
 
     def __init__(self, source_node, source_channel,
                  sink_node, sink_channel,
@@ -364,6 +370,40 @@ class SchemeLink(QObject):
         state : SchemeLink.State
         """
         return self.__state
+
+    def set_runtime_state_flag(self, flag, on):
+        # type: (State, bool) -> None
+        """
+        Set/unset runtime state flag.
+
+        Parameters
+        ----------
+        flag: SchemeLink.State
+        on: bool
+        """
+        if on:
+            state = self.__state | flag
+        else:
+            state = self.__state & ~flag
+        self.set_runtime_state(state)
+
+    def test_runtime_state(self, flag):
+        # type: (State) -> bool
+        """
+        Test if runtime state flag is on/off
+
+        Parameters
+        ----------
+        flag: SchemeLink.State
+            State flag to test
+
+        Returns
+        -------
+        on: bool
+            True if `flag` is set; False otherwise.
+
+        """
+        return bool(self.__state & flag)
 
     def set_tool_tip(self, tool_tip):
         # type: (str) -> None

--- a/orangecanvas/scheme/link.py
+++ b/orangecanvas/scheme/link.py
@@ -191,17 +191,19 @@ class SchemeLink(QObject):
         """
         Flags indicating the runtime state of a link
         """
-        #: The link has no associated state.
+        #: The link has no associated state (e.g. is not associated with any
+        #: execution contex)
         NoState = 0
-        #: A link is empty when it has no value on it
+        #: A link is empty when it has no value on it.
         Empty = 1
-        #: A link is active when the source node provides a value on output
+        #: A link is active when the source node provides a value on output.
         Active = 2
         #: A link is pending when it's sink node has not yet been notified
         #: of a change (note that Empty|Pending is a valid state)
         Pending = 4
-        #: The link's source has been is invalidated. Until this flag is
-        #: cleared no dependent nodes will receive new signals.
+        #: The link's source node has invalidated the source channel.
+        #: The execution manager should not propagate this links source value
+        #: until this flag is cleared.
         #:
         #: .. versionadded:: 0.1.8
         Invalidated = 8

--- a/orangecanvas/scheme/node.py
+++ b/orangecanvas/scheme/node.py
@@ -4,13 +4,15 @@ Scheme Node
 ===========
 
 """
+import enum
 import warnings
-from typing import Optional, Dict, Any, List, Tuple, Iterable
+from typing import Optional, Dict, Any, List, Tuple, Iterable, Union
 
-from AnyQt.QtCore import QObject
+from AnyQt.QtCore import QObject, QCoreApplication
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 
 from ..registry import WidgetDescription, InputSignal, OutputSignal
+from .events import NodeEvent
 
 
 class UserMessage(object):
@@ -57,6 +59,38 @@ class SchemeNode(QObject):
         Parent object.
 
     """
+    class State(enum.IntEnum):
+        """
+        A workflow node's runtime state flags
+        """
+        #: The node has no state.
+        NoState = 0
+
+        #: The node is running (i.e. executing a task).
+        Running = 1
+
+        #: The node has invalidated inputs. This flag is set when:
+        #:
+        #: * An input link is added or removed
+        #: * An input link is marked as pending
+        #:
+        #: It is set/cleared by the execution manager when the inputs are
+        #: propagated to the node.
+        Pending = 2
+
+        #: The node has invalidated outputs. Execution manager should not
+        #: propagate this node's existing outputs to dependent nodes until
+        #: this flag is cleared.
+        Invalidated = 4
+
+        #: The node is not in a state where it can accept inputs.
+        Blocking = 8
+
+    NoState = State.NoState
+    Running = State.Running
+    Pending = State.Pending
+    Invalidated = State.Invalidated
+    Blocking = State.Blocking
 
     def __init__(self, description, title=None, position=None,
                  properties=None, parent=None):
@@ -73,6 +107,7 @@ class SchemeNode(QObject):
         self.__processing_state = 0
         self.__status_message = ""
         self.__state_messages = {}  # type: Dict[str, UserMessage]
+        self.__state = SchemeNode.NoState  # type: Union[SchemeNode.State, int]
         self.properties = properties or {}
 
     def input_channels(self):
@@ -177,15 +212,13 @@ class SchemeNode(QObject):
         """
         Set the node processing state.
         """
-        if self.__processing_state != state:
-            self.__processing_state = state
-            self.processing_state_changed.emit(state)
+        self.set_state_flags(SchemeNode.Running, bool(state))
 
     def processing_state(self):
         """
         The node processing state, 0 for not processing, 1 the node is busy.
         """
-        return self.__processing_state
+        return int(bool(self.state() & SchemeNode.Running))
 
     processing_state = Property(int, fset=set_processing_state,  # type: ignore
                                 fget=processing_state)
@@ -263,6 +296,69 @@ class SchemeNode(QObject):
         Return a list of all state messages.
         """
         return self.__state_messages.values()
+
+    state_changed = Signal(int)
+
+    def set_state(self, state):
+        # type: (Union[State, int]) -> None
+        """
+        Set the node runtime state flags
+
+        Parameters
+        ----------
+        state: SchemeNode.State
+        """
+        if self.__state != state:
+            curr = self.__state
+            self.__state = state
+            QCoreApplication.sendEvent(
+                self, NodeEvent(NodeEvent.NodeStateChange, self)
+            )
+            self.state_changed.emit(state)
+            if curr & SchemeNode.Running != state & SchemeNode.Running:
+                self.processing_state_changed.emit(
+                    int(bool(state & SchemeNode.Running))
+                )
+
+    def state(self):
+        # type: () -> Union[State, int]
+        """
+        Return the node runtime state flags.
+        """
+        return self.__state
+
+    def set_state_flags(self, flags, on):
+        # type: (Union[State, int], bool) -> None
+        """
+        Set the specified state flags on/off.
+
+        Parameters
+        ----------
+        flags: SchemeNode.State
+            Flag to modify
+        on: bool
+            Turn the flag on or off
+        """
+        if on:
+            state = self.__state | flags
+        else:
+            state = self.__state & ~flags
+        self.set_state(state)
+
+    def test_state_flags(self, flag):
+        # type: (State) -> bool
+        """
+        Return True/False if the runtime state flag is set.
+
+        Parameters
+        ----------
+        flag: SchemeNode.State
+
+        Returns
+        -------
+        val: bool
+        """
+        return bool(self.__state & flag)
 
     def __str__(self):
         return "SchemeNode(description_id=%r, title=%r, ...)" % \

--- a/orangecanvas/scheme/node.py
+++ b/orangecanvas/scheme/node.py
@@ -83,14 +83,16 @@ class SchemeNode(QObject):
         #: this flag is cleared.
         Invalidated = 4
 
-        #: The node is not in a state where it can accept inputs.
-        Blocking = 8
+        #: The node is in a state where it does not accept new signals.
+        #: The execution manager should not propagate inputs to this node
+        #: until this flag is cleared.
+        NotReady = 8
 
     NoState = State.NoState
     Running = State.Running
     Pending = State.Pending
     Invalidated = State.Invalidated
-    Blocking = State.Blocking
+    NotReady = State.NotReady
 
     def __init__(self, description, title=None, position=None,
                  properties=None, parent=None):

--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -552,11 +552,6 @@ class SignalManager(QObject):
         If no node is eligible for update do nothing and return `False`.
         """
         node_update_front = self.node_update_front()
-        _ = lambda nodes: list(map(attrgetter('title'), nodes))
-        log.debug("Pending nodes: %s", _(self.pending_nodes()))
-        log.debug("Blocking nodes: %s", _(self.blocking_nodes()))
-        log.debug("Invalidated nodes: %s", _(self.invalidated_nodes()))
-        log.debug("Nodes ready for update: %s", _(node_update_front))
         if node_update_front:
             self.process_node(node_update_front[0])
             return True
@@ -924,6 +919,12 @@ class SignalManager(QObject):
         log.info("'UpdateRequest' event, queued signals: %i, nactive: %i "
                  "(MAX_CONCURRENT: %i)",
                  len(self.__input_queue), nactive, MAX_CONCURRENT)
+
+        _ = lambda nodes: list(map(attrgetter('title'), nodes))
+        log.debug("Pending nodes: %s", _(self.pending_nodes()))
+        log.debug("Blocking nodes: %s", _(self.blocking_nodes()))
+        log.debug("Invalidated nodes: %s", _(self.invalidated_nodes()))
+        log.debug("Nodes ready for update: %s", _(eligible))
 
         # Return if over committed, except in the case that one of the the
         # eligible nodes is already active (a form of implicit cancellation)

--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -23,7 +23,7 @@ from typing import (
     Sequence, Union, DefaultDict
 )
 
-from AnyQt.QtCore import QObject, QTimer, QEvent
+from AnyQt.QtCore import QObject, QTimer
 from AnyQt.QtCore import pyqtSignal, pyqtSlot as Slot
 
 from ..utils import unique
@@ -920,38 +920,6 @@ class SignalManager(QObject):
         if self.__state == SignalManager.Running and \
                 not self.__update_timer.isActive():
             self.__update_timer.start()
-
-    def eventFilter(self, receiver, event):
-        """
-        Reimplemented.
-        """
-        if event.type() == QEvent.DeferredDelete \
-                and receiver is self.__workflow:
-            # ?? This is really, probably, mostly, likely not needed. Should
-            # just raise error from __process_next.
-            state = self.runtime_state()
-            if state == SignalManager.Processing:
-                log.critical(
-                    "The workflow model %r received a deferred delete request "
-                    "while performing an input update. "
-                    "Deferring a 'DeferredDelete' event for the workflow "
-                    "until SignalManager exits the current update step.",
-                    self.__workflow
-                )
-                warnings.warn(
-                    "The workflow model received a deferred delete request "
-                    "while updating inputs. In the future this will raise "
-                    "a RuntimeError", _FutureRuntimeWarning,
-                )
-                event.setAccepted(False)
-                self.processingFinished.connect(self.__workflow.deleteLater)
-                self.stop()
-                return True
-        return super().eventFilter(receiver, event)
-
-
-class _FutureRuntimeWarning(FutureWarning, RuntimeWarning):
-    pass
 
 
 def can_enable_dynamic(link, value):

--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -19,7 +19,8 @@ from functools import partial, reduce
 
 import typing
 from typing import (
-    Any, Optional, List, Tuple, NamedTuple, Iterable, Callable, Set, Dict
+    Any, Optional, List, Tuple, NamedTuple, Iterable, Callable, Set, Dict,
+    Sequence, Union, DefaultDict
 )
 
 from AnyQt.QtCore import QObject, QTimer, QEvent
@@ -69,6 +70,23 @@ class Signal(
 is_enabled = attrgetter("enabled")
 
 MAX_CONCURRENT = 1
+
+
+class _OutputState:
+    """Output state for a single node/channel"""
+    __slots__ = ('flags', 'outputs')
+    #: Flag indicating the output on the channel is invalidated.
+    Invalidated = 1
+
+    def __init__(self):
+        self.outputs = defaultdict()
+        self.flags = 0
+
+    def __repr__(self):
+        return "State(flags={}, outputs={!r})".format(
+            self.flags, dict(self.outputs)
+        )
+    __str__ = __repr__
 
 
 class SignalManager(QObject):
@@ -143,7 +161,7 @@ class SignalManager(QObject):
         self.__input_queue = []  # type: List[Signal]
 
         # mapping a node to its current outputs
-        self.__node_outputs = {}  # type: Dict[SchemeNode, Dict[OutputSignal, Dict[Any, Any]]]
+        self.__node_outputs = {}  # type: Dict[SchemeNode, DefaultDict[OutputSignal, _OutputState]]
 
         self.__state = SignalManager.Running
         self.__runtime_state = SignalManager.Waiting
@@ -203,7 +221,7 @@ class SignalManager(QObject):
             workflow.link_added.connect(self.__on_link_added)
             workflow.link_removed.connect(self.__on_link_removed)
             for node in workflow.nodes:
-                self.__node_outputs[node] = defaultdict(dict)
+                self.__node_outputs[node] = defaultdict(_OutputState)
             for link in workflow.links:
                 link.enabled_changed.connect(self.__on_link_enabled_changed)
             workflow.installEventFilter(self)
@@ -283,7 +301,7 @@ class SignalManager(QObject):
         return self.__state
 
     def _set_runtime_state(self, state):
-        # type: (RuntimeState) -> None
+        # type: (Union[RuntimeState, int]) -> None
         """
         Set the runtime state.
 
@@ -303,6 +321,7 @@ class SignalManager(QObject):
         return self.__runtime_state
 
     def __on_node_removed(self, node):
+        # type: (SchemeNode) -> None
         # remove all pending input signals for node so we don't get
         # stale references in process_node.
         # NOTE: This does not remove output signals for this node. In
@@ -314,11 +333,18 @@ class SignalManager(QObject):
         del self.__node_outputs[node]
 
     def __on_node_added(self, node):
-        self.__node_outputs[node] = defaultdict(dict)
+        # type: (SchemeNode) -> None
+        self.__node_outputs[node] = defaultdict(_OutputState)
 
     def __on_link_added(self, link):
+        # type: (SchemeLink) -> None
         # push all current source values to the sink
         link.set_runtime_state(SchemeLink.Empty)
+        state = self.__node_outputs[link.source_node][link.source_channel]
+        link.set_runtime_state_flag(
+            SchemeLink.Invalidated,
+            bool(state.flags & _OutputState.Invalidated)
+        )
         if link.enabled:
             log.info("Scheduling signal data update for '%s'.", link)
             self._schedule(self.signals_on_link(link))
@@ -327,6 +353,7 @@ class SignalManager(QObject):
         link.enabled_changed.connect(self.__on_link_enabled_changed)
 
     def __on_link_removed(self, link):
+        # type: (SchemeLink) -> None
         # purge all values in sink's queue
         log.info("Scheduling signal data purge (%s).", link)
         self.purge_link(link)
@@ -360,7 +387,7 @@ class SignalManager(QObject):
         node, channel = link.source_node, link.source_channel
 
         if node in self.__node_outputs:
-            return self.__node_outputs[node][channel]
+            return self.__node_outputs[node][channel].outputs
         else:
             # if the the node was already removed its tracked outputs in
             # __node_outputs are cleared, however the final 'None' signal
@@ -395,7 +422,14 @@ class SignalManager(QObject):
 
         scheme = self.__workflow
 
-        self.__node_outputs[node][channel][id] = value
+        state = self.__node_outputs[node][channel]
+        state.outputs[id] = value
+
+        # clear invalidated flag
+        if state.flags & _OutputState.Invalidated:
+            log.debug("%r clear invalidated flag on channel %r",
+                      node.title, channel.name)
+            state.flags &= ~_OutputState.Invalidated
 
         links = filter(
             is_enabled,
@@ -404,8 +438,41 @@ class SignalManager(QObject):
         signals = []
         for link in links:
             signals.append(Signal(link, value, id))
+            link.set_runtime_state_flag(SchemeLink.Invalidated, False)
 
         self._schedule(signals)
+
+    def invalidate(self, node, channel):
+        # type: (SchemeNode, OutputSignal) -> None
+        """
+        Invalidate the `channel` on `node`.
+
+        The channel is effectively considered changed but unavailable until
+        a new value is sent via `send`. While this state is set the dependent
+        nodes will not be updated.
+
+        All links originating with this node/channel will be marked with
+        `SchemeLink.Invalidated` flag until a new value is sent with `send`.
+
+        Parameters
+        ----------
+        node: SchemeNode
+            The originating node.
+        channel: OutputSignal
+            The channel to invalidate.
+
+
+        .. versionadded:: 0.1.8
+        """
+        log.debug("%r invalidating channel %r", node.title, channel.name)
+        self.__node_outputs[node][channel].flags |= _OutputState.Invalidated
+        if self.__workflow is None:
+            return
+        links = self.__workflow.find_links(
+            source_node=node, source_channel=channel
+        )
+        for link in links:
+            link.set_runtime_state(link.runtime_state() | link.Invalidated)
 
     def purge_link(self, link):
         # type: (SchemeLink) -> None
@@ -466,11 +533,12 @@ class SignalManager(QObject):
         if not self._can_process():
             raise RuntimeError("Can't process in state %i" % self.__state)
 
-        log.info("SignalManager: Processing queued signals")
-
         node_update_front = self.node_update_front()
-        log.debug("SignalManager: Nodes eligible for update %s",
-                  [node.title for node in node_update_front])
+        _ = lambda nodes: list(map(attrgetter('title'), nodes))
+        log.info("SignalManager: Processing queued signals")
+        log.debug("Pending nodes: %s", _(self.pending_nodes()))
+        log.debug("Blocking nodes: %s", _(self.blocking_nodes()))
+        log.debug("Nodes ready for update: %s", _(node_update_front))
 
         if node_update_front:
             self.process_node(node_update_front[0])
@@ -625,6 +693,20 @@ class SignalManager(QObject):
         else:
             return [node for node in workflow.nodes if self.is_blocking(node)]
 
+    def invalidated_nodes(self):
+        # type: () -> List[SchemeNode]
+        """
+        Return a list of invalidated nodes.
+
+        .. versionadded:: 0.1.8
+        """
+        workflow = self.__workflow
+        if workflow is None:
+            return []
+        else:
+            return [node for node in workflow.nodes
+                    if self.has_invalidated_outputs(node)]
+
     def is_blocking(self, node):
         # type: (SchemeNode) -> bool
         """
@@ -635,12 +717,67 @@ class SignalManager(QObject):
         it does so.
 
         The default implementation returns False.
+
+        .. deprecated:: 0.1.8
         """
-        # TODO: this needs a different name
         return False
 
+    def has_invalidated_outputs(self, node):
+        # type: (SchemeNode) -> bool
+        """
+        Does node have any explicitly invalidated outputs.
+
+        Parameters
+        ----------
+        node: SchemeNode
+
+        Returns
+        -------
+        state: bool
+
+        See also
+        --------
+        invalidate
+
+
+        .. versionadded:: 0.1.8
+        """
+        out = self.__node_outputs.get(node)
+        if out is not None:
+            return any(state.flags & _OutputState.Invalidated
+                       for state in out.values())
+        else:
+            return False
+
+    def has_invalidated_inputs(self, node):
+        # type: (SchemeNode) -> bool
+        """
+        Does the node have any immediate ancestor with invalidated outputs.
+
+        Parameters
+        ----------
+        node : SchemeNode
+
+        Returns
+        -------
+        state: bool
+
+        Note
+        ----
+        The node's ancestors are only computed over enabled links.
+
+
+        .. versionadded:: 0.1.8
+        """
+        if self.__workflow is None:
+            return False
+        workflow = self.__workflow
+        return any(self.has_invalidated_outputs(link.source_node)
+                   for link in workflow.find_links(sink_node=node)
+                   if link.is_enabled())
+
     def node_update_front(self):
-        # type: () -> List[SchemeNode]
+        # type: () -> Sequence[SchemeNode]
         """
         Return a list of nodes on the update front, i.e. nodes scheduled for
         an update that have no ancestor which is either itself scheduled
@@ -650,33 +787,36 @@ class SignalManager(QObject):
         ----
         The node's ancestors are only computed over enabled links.
         """
-        scheme = self.__workflow
-        if scheme is None:
+        if self.__workflow is None:
             return []
+        workflow = self.__workflow
+        expand = partial(expand_node, workflow)
 
-        def expand(node):
-            return [link.sink_node
-                    for link in scheme.find_links(source_node=node)
-                    if link.enabled]
-
-        components = strongly_connected_components(scheme.nodes, expand)
+        components = strongly_connected_components(workflow.nodes, expand)
         node_scc = {node: scc for scc in components for node in scc}
 
-        def isincycle(node):
-            # type: (SchemeNode) -> bool
+        def isincycle(node):  # type: (SchemeNode) -> bool
             return len(node_scc[node]) > 1
 
-        # a list of all nodes currently active/executing a task.
+        def dependents(node):  # type: (SchemeNode) -> List[SchemeNode]
+            return dependent_nodes(workflow, node)
+
+        # A list of all nodes currently active/executing a non-interruptable
+        # task.
         blocking_nodes = set(self.blocking_nodes())
+        # nodes marked as having invalidated outputs (not yet available)
+        invalidated_nodes = set(self.invalidated_nodes())
 
-        dependents = partial(dependent_nodes, scheme)
-
-        blocked_nodes = reduce(set.union,
-                               map(dependents, blocking_nodes),
-                               set(blocking_nodes))
+        #: transitive invalidated nodes (including the legacy self.is_blocked
+        #: behaviour)
+        invalidated_ = reduce(
+            set.union,
+            map(dependents, invalidated_nodes | blocking_nodes),
+            set([]),
+        )  # type: Set[SchemeNode]
 
         pending = self.pending_nodes()
-        pending_downstream = set()
+        pending_ = set()
         for n in pending:
             depend = set(dependents(n))
             if isincycle(n):
@@ -685,13 +825,22 @@ class SignalManager(QObject):
                 # by the workflow execution.
                 cc = node_scc[n]
                 depend -= set(cc)
-            pending_downstream.update(depend)
+            pending_.update(depend)
 
-        log.debug("Pending nodes: %s", pending)
-        log.debug("Blocking nodes: %s", blocking_nodes)
+        def has_invalidated_ancestor(node):  # type: (SchemeNode) -> bool
+            return node in invalidated_
 
-        noneligible = pending_downstream | blocked_nodes
-        return [node for node in pending if node not in noneligible]
+        def has_pending_ancestor(node):  # type: (SchemeNode) -> bool
+            return node in pending_
+
+        #: nodes that are eligible for update.
+        ready = list(filter(
+            lambda node: not has_pending_ancestor(node)
+                         and not has_invalidated_ancestor(node)
+                         and not self.is_blocking(node),
+            pending
+        ))
+        return ready
 
     @Slot()
     def __process_next(self):
@@ -805,6 +954,13 @@ def compress_signals(signals):
     return list(reversed(signals))
 
 
+def expand_node(workflow, node):
+    # type: (Scheme, SchemeNode) -> List[SchemeNode]
+    return [link.sink_node
+            for link in workflow.find_links(source_node=node)
+            if link.enabled]
+
+
 def dependent_nodes(scheme, node):
     # type: (Scheme, SchemeNode) -> List[SchemeNode]
     """
@@ -815,12 +971,7 @@ def dependent_nodes(scheme, node):
     ----
     This does not include nodes only reachable by disables links.
     """
-    def expand(node):
-        return [link.sink_node
-                for link in scheme.find_links(source_node=node)
-                if link.enabled]
-
-    nodes = list(traverse_bf(node, expand))
+    nodes = list(traverse_bf(node, partial(expand_node, scheme)))
     assert nodes[0] is node
     # Remove the first item (`node`).
     return nodes[1:]

--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -709,7 +709,8 @@ class SignalManager(QObject):
         .. versionadded:: 0.1.8
         """
         return [node for node in self.__nodes()
-                if self.has_invalidated_outputs(node)]
+                if self.has_invalidated_outputs(node) or
+                self.is_invalidated(node)]
 
     def active_nodes(self):
         # type: () -> List[SchemeNode]
@@ -734,6 +735,20 @@ class SignalManager(QObject):
         .. deprecated:: 0.1.8
         """
         return False
+
+    def is_invalidated(self, node: SchemeNode) -> bool:
+        """
+        Is the node marked as invalidated.
+
+        Parameters
+        ----------
+        node : SchemeNode
+
+        Returns
+        -------
+        state: bool
+        """
+        return node.test_state_flags(SchemeNode.Invalidated)
 
     def has_invalidated_outputs(self, node):
         # type: (SchemeNode) -> bool

--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -501,6 +501,10 @@ class SignalManager(QObject):
                 state = SchemeLink.Empty
             link.set_runtime_state(state | SchemeLink.Pending)
 
+        for node in {sig.link.sink_node for sig in signals}:  # type: SchemeNode
+            # update the SchemeNodes's runtime state flags
+            node.set_state_flags(SchemeNode.Pending, True)
+
         if signals:
             self.updatesPending.emit()
 
@@ -590,6 +594,7 @@ class SignalManager(QObject):
         try:
             self.send_to_node(node, signals_in)
         finally:
+            node.set_state_flags(SchemeNode.Pending, False)
             self.processingFinished.emit()
             self.processingFinished[SchemeNode].emit(node)
             self._set_runtime_state(SignalManager.Waiting)

--- a/orangecanvas/scheme/tests/test_signalmanager.py
+++ b/orangecanvas/scheme/tests/test_signalmanager.py
@@ -130,6 +130,26 @@ class TestSignalManager(unittest.TestCase):
         self.assertNotIn(n2, sm.node_update_front())
         self.assertTrue(sm.has_invalidated_inputs(n2))
 
+    def test_pending_flags(self):
+        workflow = self.scheme
+        sm = TestingSignalManager()
+        sm.set_workflow(workflow)
+        sm.start()
+        n0, n1, n3 = workflow.nodes[:3]
+        l0, l1 = workflow.links[:2]
+
+        self.assertFalse(n3.test_state_flags(SchemeNode.Pending))
+        self.assertFalse(l0.runtime_state() & SchemeLink.Pending)
+        sm.send(n0, n0.description.outputs[0], 'hello', None)
+        self.assertTrue(n3.test_state_flags(SchemeNode.Pending))
+        self.assertTrue(l0.runtime_state() & SchemeLink.Pending)
+
+        spy = QSignalSpy(sm.processingFinished)
+        assert spy.wait()
+
+        self.assertFalse(n3.test_state_flags(SchemeNode.Pending))
+        self.assertFalse(l0.runtime_state() & SchemeLink.Pending)
+
     def test_compress_signals(self):
         workflow = self.scheme
         link = workflow.links[0]

--- a/orangecanvas/scheme/tests/test_signalmanager.py
+++ b/orangecanvas/scheme/tests/test_signalmanager.py
@@ -3,7 +3,7 @@ import unittest
 from AnyQt.QtWidgets import QApplication
 from AnyQt.QtTest import QSignalSpy
 
-from orangecanvas.scheme import Scheme, SchemeNode
+from orangecanvas.scheme import Scheme, SchemeNode, SchemeLink
 from orangecanvas.scheme import signalmanager
 from orangecanvas.scheme.signalmanager import (
     SignalManager, Signal,  compress_signals
@@ -44,6 +44,7 @@ class TestSignalManager(unittest.TestCase):
         add = scheme.new_node(reg.widget("add"))
         scheme.new_link(zero, "value", add, "left")
         scheme.new_link(one, "value", add, "right")
+        self.reg = reg
         self.scheme = scheme
 
     def test(self):
@@ -79,6 +80,55 @@ class TestSignalManager(unittest.TestCase):
 
         self.assertEqual(n3.property("-input-left"), None)
         self.assertEqual(n3.property("-input-right"), 'hello')
+
+    def test_invalidated_flags(self):
+        workflow = self.scheme
+        sm = TestingSignalManager()
+        sm.set_workflow(workflow)
+        sm.start()
+
+        n0, n1, n2 = workflow.nodes[:3]
+        l0, l1 = workflow.links[:2]
+
+        self.assertFalse(l0.runtime_state() & SchemeLink.Invalidated)
+        sm.send(n0, n0.description.outputs[0], 'hello', None)
+        self.assertFalse(l0.runtime_state() & SchemeLink.Invalidated)
+        self.assertIn(n2, sm.node_update_front())
+
+        sm.invalidate(n0, n0.description.outputs[0])
+        self.assertTrue(l0.runtime_state() & SchemeLink.Invalidated)
+        self.assertTrue(sm.has_invalidated_outputs(n0))
+        self.assertTrue(sm.has_invalidated_inputs(n2))
+        self.assertNotIn(n2, sm.node_update_front())
+
+        sm.send(n0, n0.description.outputs[0], 'hello', None)
+        self.assertFalse(l0.runtime_state() & SchemeLink.Invalidated)
+        self.assertFalse(sm.has_invalidated_outputs(n0))
+        self.assertFalse(sm.has_invalidated_inputs(n2))
+        self.assertIn(n2, sm.node_update_front())
+
+        sm.invalidate(n1, n1.description.outputs[0])
+        n3 = workflow.new_node(self.reg.widget('add'))
+        l2 = workflow.new_link(
+            n1, n1.output_channel('value'), n3, n3.input_channel('left')
+        )
+
+        self.assertTrue(l2.test_runtime_state(SchemeLink.Invalidated))
+        self.assertTrue(sm.has_invalidated_inputs(n3))
+        self.assertNotIn(n3, sm.node_update_front())
+
+        workflow.remove_link(l2)
+        self.assertFalse(sm.has_invalidated_inputs(n3))
+        self.assertNotIn(n3, sm.node_update_front())
+
+        # invalidated must not propagate via disabled links
+        self.assertNotIn(n2, sm.node_update_front())
+        l1.set_enabled(False)
+        self.assertIn(n2, sm.node_update_front())
+        self.assertFalse(sm.has_invalidated_inputs(n2))
+        l1.set_enabled(True)
+        self.assertNotIn(n2, sm.node_update_front())
+        self.assertTrue(sm.has_invalidated_inputs(n2))
 
     def test_compress_signals(self):
         workflow = self.scheme

--- a/orangecanvas/scheme/tests/test_widgetmanager.py
+++ b/orangecanvas/scheme/tests/test_widgetmanager.py
@@ -5,7 +5,7 @@ import unittest
 from AnyQt.QtWidgets import QWidget, QApplication, QAction
 from AnyQt.QtTest import QSignalSpy
 
-from orangecanvas.scheme import Scheme, NodeEvent
+from orangecanvas.scheme import Scheme, NodeEvent, SchemeLink, LinkEvent
 from orangecanvas.scheme.widgetmanager import WidgetManager
 from orangecanvas.registry import tests as registry_tests
 from orangecanvas.scheme.tests import EventSpy
@@ -185,6 +185,11 @@ class TestWidgetManager(unittest.TestCase):
         w1._evt.clear()
         workflow.set_runtime_env("tt", "aaa")
         self.assertIn(NodeEvent.WorkflowEnvironmentChange, w1._evt)
+
+        w3._evt.clear()
+        l1.set_runtime_state(SchemeLink.Pending)
+        self.assertIn(LinkEvent.InputLinkStateChange, w3._evt)
+        self.assertIn(LinkEvent.OutputLinkStateChange, w1._evt)
 
     def test_actions(self):
         workflow = self.scheme

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -595,15 +595,26 @@ class WidgetManager(QObject):
         if isinstance(recv, SchemeNode):
             if event.type() == NodeEvent.NodeActivateRequest:
                 self.__activate_widget_for_node(recv)
-            elif event.type() in (
-                    LinkEvent.InputLinkStateChange,
-                    LinkEvent.OutputLinkStateChange,
-            ):
-                item = self.__item_for_node.get(recv)
-                # dispatch the event to the gui widget
-                if item is not None and item.widget is not None:
-                    QCoreApplication.sendEvent(item.widget, event)
+            self.__dispatch_events(recv, event)
         return False
+
+    def __dispatch_events(self, node: Node, event: QEvent) -> None:
+        """
+        Dispatch relevant workflow events to the GUI widget
+        """
+        if event.type() in (
+            WorkflowEvent.InputLinkAdded,
+            WorkflowEvent.InputLinkRemoved,
+            WorkflowEvent.InputLinkStateChange,
+            WorkflowEvent.OutputLinkAdded,
+            WorkflowEvent.OutputLinkRemoved,
+            WorkflowEvent.OutputLinkStateChange,
+            WorkflowEvent.NodeStateChange,
+            WorkflowEvent.WorkflowEnvironmentChange,
+        ):
+            item = self.__item_for_node.get(node)
+            if item is not None and item.widget is not None:
+                QCoreApplication.sendEvent(item.widget, event)
 
     def __set_float_on_top_flag(self, widget):
         # type: (QWidget) -> None

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -53,12 +53,16 @@ class WidgetManager(QObject):
     The widgets created with :func:`create_widget_for_node` will automatically
     receive dispatched events:
 
-        * :data:`WorkflowEvent.InputLinkAdded` - when a new input link is added to
-          the workflow.
-        * :data:`LinkEvent.InputLinkRemoved` - when a input link is removed
-        * :data:`LinkEvent.OutputLinkAdded` - when a new output link is added to
-          the workflow
-        * :data:`LinkEvent.InputLinkRemoved` - when a output link is removed
+        * :data:`WorkflowEvent.InputLinkAdded` - when a new input link is
+          added to the workflow.
+        * :data:`LinkEvent.InputLinkRemoved` - when a input link is removed.
+        * :data:`LinkEvent.OutputLinkAdded` - when a new output link is
+          added to the workflow.
+        * :data:`LinkEvent.InputLinkRemoved` - when a output link is removed.
+        * :data:`LinkEvent.InputLinkStateChanged` - when the input link's
+          runtime state changes.
+        * :data:`LinkEvent.OutputLinkStateChanged` - when the output link's
+          runtime state changes.
         * :data:`WorkflowEnvEvent.WorkflowEnvironmentChanged` - when the
           workflow environment changes.
 
@@ -588,9 +592,17 @@ class WidgetManager(QObject):
 
     def eventFilter(self, recv, event):
         # type: (QObject, QEvent) -> bool
-        if event.type() == NodeEvent.NodeActivateRequest \
-                and isinstance(recv, SchemeNode):
-            self.__activate_widget_for_node(recv)
+        if isinstance(recv, SchemeNode):
+            if event.type() == NodeEvent.NodeActivateRequest:
+                self.__activate_widget_for_node(recv)
+            elif event.type() in (
+                    LinkEvent.InputLinkStateChange,
+                    LinkEvent.OutputLinkStateChange,
+            ):
+                item = self.__item_for_node.get(recv)
+                # dispatch the event to the gui widget
+                if item is not None and item.widget is not None:
+                    QCoreApplication.sendEvent(item.widget, event)
         return False
 
     def __set_float_on_top_flag(self, widget):

--- a/orangecanvas/utils/__init__.py
+++ b/orangecanvas/utils/__init__.py
@@ -3,7 +3,7 @@ import types
 from functools import reduce
 
 import typing
-from typing import Iterable, Set, Any, Optional, Union, Tuple, Callable
+from typing import Iterable, Set, Any, Optional, Union, Tuple, Callable, Mapping
 
 from .qtcompat import toPyObject
 
@@ -20,10 +20,13 @@ __all__ = [
     "unique",
     "assocv",
     "assocf",
+    "mapping_get"
 ]
 
 if typing.TYPE_CHECKING:
     H = typing.TypeVar("H", bound=typing.Hashable)
+    A = typing.TypeVar("A")
+    B = typing.TypeVar("B")
     C = typing.TypeVar("C")
     K = typing.TypeVar("K")
     V = typing.TypeVar("V")
@@ -207,3 +210,19 @@ def assocf(seq, predicate):
         if predicate(k):
             return k, v
     return None
+
+
+def mapping_get(
+    mapping,  # type: Mapping[K, V]
+    key,      # type: K
+    type,     # type: Callable[[V], A]
+    default,  # type: B
+):  # type: (...) -> Union[A, B]
+    try:
+        val = mapping[key]
+    except KeyError:
+        return default
+    try:
+        return type(val)
+    except (TypeError, ValueError):
+        return default


### PR DESCRIPTION
## Issue 

`SignalManager.is_blocking` is insufficient (the current and only async execution support).
While in this state the widget will not receive any signal inputs, neither will all its dependents. It would be beneficial to split the state into two:

* Prevent signal delivery to this node.
* Prevent signal delivery to its dependents (or even delivery of only specific outputs).

## Changes

* `SignalManager.is_ready` indicates if a node can receive new input signals.
* `SignalManager.is_invalidated` indicates all outputs should be considered invalidated.
* `SignalManager.invalidate` invalidates a single output channel.

