### PR TITLE
Quick menu macOS size grip

### DIFF
--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -1509,6 +1509,12 @@ class QuickMenu(FramelessWindow):
             size = self.size()
         else:
             size = self.sizeHint()
+            settings = QSettings()
+            ssize = settings.value('quickmenu/size', defaultValue=QSize(),
+                                   type=QSize)
+            if ssize.isValid():
+                size.setHeight(ssize.height())
+                size = size.expandedTo(self.minimumSizeHint())
 
         desktop = QApplication.desktop()
         screen_geom = desktop.availableGeometry(pos)
@@ -1570,6 +1576,8 @@ class QuickMenu(FramelessWindow):
         """
         Reimplemented from :class:`QWidget`
         """
+        settings = QSettings()
+        settings.setValue('quickmenu/size', self.size())
         super().hideEvent(event)
         if self.__loop:
             self.__loop.exit()


### PR DESCRIPTION
1. On macOS quick menu does not have a size grip and so cannot be resized like on other platforms.
   Fixed by forcing non zero size on the size grip.

2. The size only persists within a single editor window.
   Fixed by storing the size on menu hide event and restoring on first show.