### PR TITLE
Cancel new link action on ESC

### DIFF
--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -284,6 +284,8 @@ class NewLinkAction(UserInteraction):
         # An QUndoCommand
         self.macro = None  # type: Optional[QUndoCommand]
 
+        self.cancelOnEsc = True
+
     def remove_tmp_anchor(self):
         # type: () -> None
         """


### PR DESCRIPTION
Sometimes I grab an anchor with the intention of adding a new widget via the quick menu, but change my mind before I let go of the mouse button. Instinctively I press ESC, with the expectation that the new link interaction will be canceled.

The base class for interactions (`UserInteraction`) defines a `self.cancelOnEsc` boolean, which is set False by default. From what I can tell, no interaction uses this option.

Should it be enabled by default, some interactions such as resize arrow, resize text, break – the object is not restored to its previous state, and undo doesn't work properly.