### PR TITLE
[FIX] widgetmanager: Add nodes to init queue in OnDemand policy

### DIFF
--- a/orangecanvas/scheme/tests/test_widgetmanager.py
+++ b/orangecanvas/scheme/tests/test_widgetmanager.py
@@ -86,6 +86,24 @@ class TestWidgetManager(unittest.TestCase):
         self.assertEqual(len(spy), 3)
         self.assertSetEqual({n for n, _ in spy}, set(nodes))
 
+    def test_create_on_demand(self):
+        workflow = self.scheme
+        nodes = workflow.nodes
+        wm = TestingWidgetManager()
+        wm.set_creation_policy(WidgetManager.OnDemand)
+        spy = QSignalSpy(wm.widget_for_node_added)
+        wm.set_workflow(workflow)
+        self.assertEqual(len(spy), 0)
+        self.assertFalse(spy.wait(30))
+        self.assertEqual(len(spy), 0)
+        w = wm.widget_for_node(nodes[0])
+        self.assertEqual(list(spy), [[nodes[0], w]])
+        # transition to normal
+        spy = QSignalSpy(wm.widget_for_node_added)
+        wm.set_creation_policy(WidgetManager.Normal)
+        self.assertTrue(spy.wait())
+        self.assertEqual(spy[0][0], nodes[1])
+
     def test_mappings(self):
         workflow = self.scheme
         nodes = workflow.nodes

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -332,9 +332,10 @@ class WidgetManager(QObject):
         node.installEventFilter(self)
         if self.__creation_policy == WidgetManager.Immediate:
             self.ensure_created(node)
-        elif self.__creation_policy == WidgetManager.Normal:
+        else:
             self.__init_queue.append(node)
-            self.__init_timer.start()
+            if self.__creation_policy == WidgetManager.Normal:
+                self.__init_timer.start()
 
     def __on_node_removed(self, node):  # type: (SchemeNode) -> None
         assert self.__workflow is not None


### PR DESCRIPTION
## Issue

If adding nodes to workflow when the widget manager is in OnDemand creation policy, and then switching to Normal, the nodes that were added are not scheduled for widget creation as the new policy would suggest.

## Fix

Add nodes to init queue to complete when/if transitioned back to Normal policy.