### PR TITLE
[FIX] controlpoints: Fix point selection/tracking on double click

### DIFF
--- a/orangecanvas/canvas/items/controlpoints.py
+++ b/orangecanvas/canvas/items/controlpoints.py
@@ -260,7 +260,8 @@ class ControlPointRect(QGraphicsObject):
         obj = toGraphicsObjectIfPossible(obj)
         if isinstance(obj, ControlPoint):
             etype = event.type()
-            if etype == QEvent.GraphicsSceneMousePress and \
+            if etype in (QEvent.GraphicsSceneMousePress,
+                         QEvent.GraphicsSceneMouseDoubleClick) and \
                     event.button() == Qt.LeftButton:
                 self.__setActiveControl(obj)
 
@@ -414,7 +415,8 @@ class ControlPointLine(QGraphicsObject):
         obj = toGraphicsObjectIfPossible(obj)
         if isinstance(obj, ControlPoint):
             etype = event.type()
-            if etype == QEvent.GraphicsSceneMousePress:
+            if etype in (QEvent.GraphicsSceneMousePress,
+                         QEvent.GraphicsSceneMouseDoubleClick):
                 self.__setActiveControl(obj)
             elif etype == QEvent.GraphicsSceneMouseRelease:
                 self.__setActiveControl(None)


### PR DESCRIPTION
## Issue

Control point edit fails on a double click.

Steps:
1) Add a Text/Arrow annotation to the workflow.
2) Select the annotation item, to start edit its geometry
3) Double click one of the displayed the control point and move it. The point is disconnected from the main item.

## Fix

Keep track of the active control point on double click.