### PR TITLE
[WIP][ENH] Autosave

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1913,8 +1913,16 @@ class CanvasMainWindow(QMainWindow):
         Close the main window.
         """
         document = self.current_document()
+        path = document.path()
         if document.isModifiedStrict():
-            if self.ask_save_changes() == QDialog.Rejected:
+            if path and self.autosave_action.isChecked():
+                curr_scheme = document.scheme()
+                assert curr_scheme is not None
+                if not self.save_scheme_to(curr_scheme, path):
+                    # if fails to save, reset path and retry
+                    document.setPath("")
+                    self.closeEvent(event)
+            elif self.ask_save_changes() == QDialog.Rejected:
                 # Reject the event
                 event.ignore()
                 return

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -392,6 +392,7 @@ class CanvasMainWindow(QMainWindow):
             shortcut=QKeySequence.New,
             icon=canvas_icons("New.svg")
         )
+
         self.open_action = QAction(
             self.tr("Open"), self,
             objectName="action-open",
@@ -400,6 +401,7 @@ class CanvasMainWindow(QMainWindow):
             shortcut=QKeySequence.Open,
             icon=canvas_icons("Open.svg")
         )
+
         self.open_and_freeze_action = QAction(
             self.tr("Open and Freeze"), self,
             objectName="action-open-and-freeze",
@@ -407,9 +409,11 @@ class CanvasMainWindow(QMainWindow):
                             "propagation."),
             triggered=self.open_and_freeze_scheme
         )
+
         self.open_and_freeze_action.setShortcut(
             QKeySequence(Qt.ControlModifier | Qt.AltModifier | Qt.Key_O)
         )
+
         self.close_window_action = QAction(
             self.tr("Close Window"), self,
             objectName="action-close-window",
@@ -417,6 +421,7 @@ class CanvasMainWindow(QMainWindow):
             shortcut=QKeySequence.Close,
             triggered=self.close,
         )
+
         self.save_action = QAction(
             self.tr("Save"), self,
             objectName="action-save",
@@ -424,6 +429,7 @@ class CanvasMainWindow(QMainWindow):
             triggered=self.save_scheme,
             shortcut=QKeySequence.Save,
         )
+
         self.save_as_action = QAction(
             self.tr("Save As ..."), self,
             objectName="action-save-as",
@@ -449,6 +455,7 @@ class CanvasMainWindow(QMainWindow):
             menuRole=QAction.QuitRole,
             shortcut=QKeySequence.Quit,
         )
+
         self.welcome_action = QAction(
             self.tr("Welcome"), self,
             objectName="welcome-action",
@@ -796,19 +803,20 @@ class CanvasMainWindow(QMainWindow):
         self.widgets_tool_box.setExclusive(
             settings.value("toolbox-dock-exclusive", False, type=bool)
         )
-
         self.toogle_margins_action.setChecked(
             settings.value("scheme-margins-enabled", False, type=bool)
         )
         self.show_output_action.setChecked(
-            settings.value("output-dock/is-visible", False, type=bool))
-
+            settings.value("output-dock/is-visible", False, type=bool)
+        )
         self.canvas_tool_dock.setQuickHelpVisible(
             settings.value("quick-help/visible", True, type=bool)
         )
-
         self.float_widgets_on_top_action.setChecked(
             settings.value("widgets-float-on-top", False, type=bool)
+        )
+        self.autosave_action.setChecked(
+            settings.value("autosave-enabled", True, type=bool)
         )
 
         self.__update_from_settings()
@@ -1947,14 +1955,14 @@ class CanvasMainWindow(QMainWindow):
                           self.dock_widget.expanded())
         settings.setValue("scheme-margins-enabled",
                           self.scheme_margins_enabled)
-
         settings.setValue("widgettoolbox/state",
                           self.widgets_tool_box.saveState())
-
         settings.setValue("quick-help/visible",
                           self.canvas_tool_dock.quickHelpVisible())
         settings.setValue("widgets-float-on-top",
                           self.float_widgets_on_top_action.isChecked())
+        settings.setValue("autosave-enabled",
+                          self.autosave_action.isChecked())
 
         settings.endGroup()
         self.help_dock.close()

--- a/orangecanvas/config.py
+++ b/orangecanvas/config.py
@@ -384,6 +384,9 @@ spec = \
      ("mainwindow/number-of-recent-schemes", int, 15,
       "Number of recent workflows to keep in history"),
 
+     ("mainwindow/autosave-enabled", bool, True,
+      ""),
+
      ("schemeedit/show-channel-names", bool, True,
       "Show channel names"),
 


### PR DESCRIPTION
Whenever the `modificationChanged` signal is emitted, a save is scheduled for after one minute. 

The signal does not seem to trigger upon changing a selection in a widget, nor on changing the position of widgets on canvas – only on adding/removing nodes and links. 

Autosave is set to be on by default.

- [X] Option in the File dropdown menu next to `Save` and `Save as`.
- [x] Store autosave preference in config file
- [x] Save every minute
- [x] Save on close