### PR TITLE
Hide workflow info dialog by default

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1037,7 +1037,7 @@ class CanvasMainWindow(QMainWindow):
         newwindow.activateWindow()
 
         settings = QSettings()
-        show = settings.value("schemeinfo/show-at-new-scheme", True,
+        show = settings.value("schemeinfo/show-at-new-scheme", False,
                               type=bool)
         if show:
             newwindow.show_scheme_properties()
@@ -1586,7 +1586,7 @@ class CanvasMainWindow(QMainWindow):
             self, windowTitle=self.tr("Workflow Info"),
         )
         dialog.setFixedSize(725, 450)
-        dialog.setShowAtNewScheme(settings.value(value_key, True, type=bool))
+        dialog.setShowAtNewScheme(settings.value(value_key, False, type=bool))
 
         def onfinished():
             # type: () -> None

--- a/orangecanvas/config.py
+++ b/orangecanvas/config.py
@@ -356,7 +356,7 @@ spec = \
      ("stylesheet", str, "orange",
       "QSS stylesheet to use"),
 
-     ("schemeinfo/show-at-new-scheme", bool, True,
+     ("schemeinfo/show-at-new-scheme", bool, False,
       "Show Workflow Properties when creating a new Workflow"),
 
      ("mainwindow/scheme-margins-enabled", bool, False,


### PR DESCRIPTION
The workflow dialog is used to set the title and description of the workflow. I believe this feature is superfluous to most Orange users.

The title is referenced in the save dialog, but this will be changed in https://github.com/biolab/orange-canvas-core/pull/43.

The description is really only used for example workflows.

The dialog is still accessible with the `i` button in the bottom-left corner, `File -> Workflow Info` and the `CMD+I` keyboard shortcut.