### PR TITLE
[FIX] Fix an error on duplicate action with empty selection

### DIFF
--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1843,6 +1843,9 @@ class SchemeEditWidget(QWidget):
         Duplicate currently selected nodes.
         """
         nodedups, linkdups = self.__copySelected()
+        if not nodedups:
+            return
+
         pos = nodes_top_left(nodedups)
         self.__paste(nodedups, linkdups, pos + DuplicateOffset,
                      commandname=self.tr("Duplicate"))
@@ -2379,8 +2382,8 @@ def nodes_top_left(nodes):
     # type: (List[SchemeNode]) -> QPointF
     """Return the top left point of bbox containing all the node positions."""
     return QPointF(
-        min(n.position[0] for n in nodes),
-        min(n.position[1] for n in nodes)
+        min((n.position[0] for n in nodes), default=0),
+        min((n.position[1] for n in nodes), default=0)
     )
 
 @contextmanager


### PR DESCRIPTION
### Issue

The 'Duplicate selected' action can raise an error when no nodes are selected:

```
---------------------------- ValueError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/document/schemeedit.py", line 1846, in __duplicateSelected
    pos = nodes_top_left(nodedups)
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/document/schemeedit.py", line 2382, in nodes_top_left
    min(n.position[0] for n in nodes),
ValueError: min() arg is an empty sequence
-------------------------------------------------------------------------------
```

### Description of changes

Do nothing no nodes are selected.


