### PR TITLE
UsageStatistics: Reconstructible workflows

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -889,7 +889,8 @@ class CanvasMainWindow(QMainWindow):
         if isinstance(widget_desc, WidgetDescription):
             scheme_widget = self.current_document()
             if scheme_widget:
-                scheme_widget.usageStatistics().set_action_type(UsageStatistics.NodeAddClick)
+                statistics = scheme_widget.usageStatistics()
+                statistics.begin_action(UsageStatistics.ToolboxClick)
                 scheme_widget.createNewNode(widget_desc)
 
     def on_quick_category_action(self, action):
@@ -1856,8 +1857,6 @@ class CanvasMainWindow(QMainWindow):
                 event.ignore()
                 return
 
-        document.usageStatistics().write_statistics()
-
         old_scheme = document.scheme()
 
         # Set an empty scheme to clear the document
@@ -1865,6 +1864,8 @@ class CanvasMainWindow(QMainWindow):
         if old_scheme is not None:
             QApplication.sendEvent(old_scheme, QEvent(QEvent.Close))
             old_scheme.deleteLater()
+
+        document.usageStatistics().close()
 
         geometry = self.saveGeometry()
         state = self.saveState(version=self.SETTINGS_VERSION)

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -465,8 +465,6 @@ class NewLinkAction(UserInteraction):
             if item:
                 # If the release was over a node item then connect them
                 node = self.scene.node_for_item(item)
-                statistics = self.document.usageStatistics()
-                statistics.set_action_type(UsageStatistics.LinkAdd)
             else:
                 # Release on an empty canvas part
                 # Show a quick menu popup for a new widget creation.
@@ -518,7 +516,8 @@ class NewLinkAction(UserInteraction):
                        for output in source.outputs
                        for input in sink.inputs)
 
-        if self.direction == self.FROM_SINK:
+        from_sink = self.direction == self.FROM_SINK
+        if from_sink:
             # Reverse the argument order.
             is_compatible = reversed_arguments(is_compatible)
             suggestion_sort = self.suggestions.get_source_suggestions(from_desc.name)
@@ -553,15 +552,11 @@ class NewLinkAction(UserInteraction):
             # stays as it was
             offset = 31 * (-1 if self.direction == self.FROM_SINK else
                            1 if self.direction == self.FROM_SOURCE else 0)
+            statistics = self.document.usageStatistics()
+            statistics.begin_extend_action(from_sink, node)
             node = self.document.newNodeHelper(desc,
                                                position=(pos.x() + offset,
                                                          pos.y()))
-            statistics = self.document.usageStatistics()
-            if self.direction == self.FROM_SINK:
-                statistics.set_action_type(UsageStatistics.NodeAddExtendFromSink)
-            else:
-                statistics.set_action_type(UsageStatistics.NodeAddExtendFromSource)
-            statistics.log_node_add(node.description.name, from_desc.name)
             return node
         else:
             return None
@@ -574,7 +569,6 @@ class NewLinkAction(UserInteraction):
         detailed dialog for link editing.
 
         """
-        stat = self.document.usageStatistics()
         try:
             possible = self.scheme.propose_links(source_node, sink_node)
 
@@ -582,8 +576,6 @@ class NewLinkAction(UserInteraction):
                       [(s1.name, s2.name, w) for s1, s2, w in possible])
 
             if not possible:
-                # should action_type have been set to LinkAdd, reset it, as no link is possible
-                stat.clear_action_type()
                 raise NoPossibleLinksError
 
             source, sink, w = possible[0]
@@ -627,7 +619,6 @@ class NewLinkAction(UserInteraction):
                     raise
                 if rstatus == EditLinksDialog.Rejected:
                     raise UserCanceledError
-                stat.set_action_type(UsageStatistics.LinkEdit)
             else:
                 # links_to_add now needs to be a list of actual SchemeLinks
                 links_to_add = [
@@ -640,8 +631,6 @@ class NewLinkAction(UserInteraction):
             self.cleanup()
 
             for link in links_to_remove:
-                stat.log_link_add(source_node.description.name, sink_node.description.name,
-                                  link.source_channel.name, link.sink_channel.name)
                 commands.RemoveLinkCommand(self.scheme, link,
                                            parent=self.macro)
 
@@ -654,12 +643,8 @@ class NewLinkAction(UserInteraction):
                 )
 
                 if not duplicate:
-                    stat.log_link_add(source_node.description.name, sink_node.description.name,
-                                      link.source_channel.name, link.sink_channel.name)
                     commands.AddLinkCommand(self.scheme, link,
                                             parent=self.macro)
-
-            stat.clear_action_type()
 
         except scheme.IncompatibleChannelTypeError:
             log.info("Cannot connect: invalid channel types.")
@@ -902,9 +887,10 @@ class NewNodeAction(UserInteraction):
             view = self.document.view()
             pos = view.mapToScene(view.mapFromGlobal(pos))
 
+            statistics = self.document.usageStatistics()
+            statistics.begin_action(UsageStatistics.QuickMenu)
             node = self.document.newNodeHelper(desc,
                                                position=(pos.x(), pos.y()))
-            self.document.usageStatistics().set_action_type(UsageStatistics.NodeAddMenu)
             self.document.addNode(node)
             return node
         else:
@@ -1110,8 +1096,6 @@ class EditNodeLinksAction(UserInteraction):
         rval = dlg.exec_()
 
         if rval == EditLinksDialog.Accepted:
-            statistics = self.document.usageStatistics()
-            statistics.set_action_type(UsageStatistics.LinkEdit)
             links_spec = dlg.links()
 
             links_to_add = set(links_spec) - set(existing_links)
@@ -1144,20 +1128,13 @@ class EditNodeLinksAction(UserInteraction):
                                                sink_channel=sink_channel)
                 assert len(links) == 1
                 self.document.removeLink(links[0])
-                statistics.log_link_remove(links[0].source_node.description.name,
-                                           links[0].sink_node.description.name,
-                                           links[0].source_channel.name, links[0].sink_channel.name)
 
             for source_channel, sink_channel in links_to_add:
                 link = scheme.SchemeLink(self.source_node, source_channel,
                                          self.sink_node, sink_channel)
 
                 self.document.addLink(link)
-                statistics.log_link_add(link.source_node.description.name,
-                                        link.sink_node.description.name,
-                                        link.source_channel.name, link.sink_channel.name)
 
-            statistics.clear_action_type()
             stack.endMacro()
 
 

--- a/orangecanvas/document/tests/test_usagestatistics.py
+++ b/orangecanvas/document/tests/test_usagestatistics.py
@@ -1,0 +1,52 @@
+from PyQt5.QtWidgets import QToolButton
+
+from orangecanvas.application.tests.test_mainwindow import TestMainWindowBase
+from orangecanvas.application.widgettoolbox import WidgetToolBox
+from orangecanvas.document.usagestatistics import UsageStatistics, EventType
+
+
+class TestLinksEditDialog(TestMainWindowBase):
+    def setUp(self):
+        super().setUp()
+        self.stats = self.w.current_document().usageStatistics()
+        self.stats.set_enabled(True)
+
+        reg = self.w.scheme_widget._SchemeEditWidget__registry
+
+        first_cat = reg.categories()[0]
+        data_descriptions = reg.widgets(first_cat)
+        self.descs = [reg.action_for_widget(desc).data() for desc in data_descriptions]
+
+        toolbox = self.w.findChild(WidgetToolBox)
+        widget = toolbox.widget(0)
+        self.buttons = widget.findChildren(QToolButton)
+
+    def tearDown(self):
+        super().tearDown()
+        self.stats._clear_action()
+        self.stats._actions = []
+        self.stats.set_enabled(False)
+
+    def test_node_add_toolbox_click(self):
+        self.assertEqual(len(self.stats._actions), 0)
+
+        w_desc = self.descs[0]
+        button = self.buttons[0]
+
+        # ToolboxClick
+        button.click()
+
+        self.assertEqual(len(self.stats._actions), 1)
+
+        log = self.stats._actions[0]
+        expected = {'Type': UsageStatistics.ToolboxClick,
+                    'Events':
+                        [
+                            {
+                                'Type': EventType.NodeAdd,
+                                'Widget Name': w_desc.name,
+                                'Widget': 0
+                            }
+                        ]
+                    }
+        self.assertEqual(expected, log)

--- a/orangecanvas/document/usagestatistics.py
+++ b/orangecanvas/document/usagestatistics.py
@@ -255,35 +255,6 @@ class UsageStatistics:
                 UnicodeDecodeError, json.JSONDecodeError):
             return []
 
-    def send_statistics(self, url: str) -> None:
-        """
-        Send the statistics to the remote at `url`.
-
-        The contents are send via POST file upload (multipart/form-data)
-
-        Does nothing if not enabled.
-
-        Parameters
-        ----------
-        url : str
-        """
-        if self.is_enabled():
-            data = self.load()
-            try:
-                r = requests.post(url, files={'file': json.dumps(data)})
-                if r.status_code != 200:
-                    log.warning("Error communicating with server while attempting to send "
-                                "usage statistics.")
-                    return
-                # success - wipe statistics file
-                log.info("Usage statistics sent.")
-                with open(self.filename(), 'w', encoding="utf-8") as f:
-                    json.dump([], f)
-            except (ConnectionError, requests.exceptions.RequestException):
-                log.warning("Connection error while attempting to send usage statistics.")
-            except Exception:
-                log.warning("Failed to send usage statistics.")
-
     def write_statistics(self):
         if not self.is_enabled():
             return


### PR DESCRIPTION
Statistics now tracks actions and events separately. A session is constructed of several actions, each of which has a type and a corresponding list of events. Concatenating all events of a session allows reconstruction of the workflow.

**Tracked events**
NodeAdd
NodeRemove
LinkAdd
LinkRemove

**Tracked actions**
Unclassified
ToolboxClick
ToolboxDrag
QuickMenu
ExtendFromSink
ExtendFromSource
InsertDrag
InsertMenu
Undo
Redo
Duplicate 
Load 

The current implementation of deleting items on canvas (`deleteSelected()`) makes it difficult to track as one action. It's fine if it's left unclassified for now. Otherwise, all canvas interactions should be accounted for. Should anything be forgotten, it will be tagged as unclassified.

**TODO**

- [x] Handle enabling/disabling statistics mid-session properly
- [x] Update documentation
- [x] Reset statistics collection permission
- Add `more info` link to:
  - [X] error reporting preferences pane
  - [x] notification request 
- [x] Update wiki page