### PR TITLE
Enable link interactions when link is below anchor

### DIFF
--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1452,8 +1452,7 @@ class SchemeEditWidget(QWidget):
             menu.popup(globalPos)
             return True
 
-        item = self.scene().item_at(scenePos, items.LinkItem,
-                                    buttons=Qt.RightButton)
+        item = self.scene().item_at(scenePos, items.LinkItem)
         if item is not None:
             link = self.scene().link_for_item(item)
             self.__linkEnableAction.setChecked(link.enabled)

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1356,8 +1356,7 @@ class SchemeEditWidget(QWidget):
             event.accept()
             return True
 
-        item = scene.item_at(event.scenePos(), items.LinkItem,
-                             buttons=Qt.LeftButton)
+        item = scene.item_at(event.scenePos(), items.LinkItem)
 
         if item is not None and event.button() == Qt.LeftButton:
             link = self.scene().link_for_item(item)


### PR DESCRIPTION
As `item_at()` only returns the top item when the `buttons` parameter is specified, links cannot be interacted with if a widget anchor is hovering over them. This became more prominent when the widget anchors' clickable area was enlarged.

This PR passes right-click and double-click events through to the link.