### PR TITLE
[FIX] addons: On prompt to restart, close all windows

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1048,7 +1048,7 @@ class AddonManagerDialog(QDialog):
 
         if QMessageBox.Ok == message_restart(self):
             self.accept()
-            self.parent().close()
+            QApplication.closeAllWindows()
         else:
             self.reject()
 


### PR DESCRIPTION
#### Issue 

The add-on dialog does quit the application when instructed to if there are multiple open editor windows.

Steps:
* Open two workfloes
* Open Add-ons
* Select something to (un)install
* Click Ok
* Click Ok again in the restart prompt dialog.

#### Changes

Close all windows not just the parent ones.