### PR TITLE
usagestatistics: Extract session registration from init into separate method

### DIFF
--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -149,6 +149,7 @@ class SchemeEditWidget(QWidget):
         self.__quickTip = ""
 
         self.__statistics = UsageStatistics(self)
+        UsageStatistics.register_session(self.__statistics)
 
         self.__undoStack = UndoStack(self, self.__statistics)
         self.__undoStack.cleanChanged[bool].connect(self.__onCleanChanged)

--- a/orangecanvas/document/usagestatistics.py
+++ b/orangecanvas/document/usagestatistics.py
@@ -74,7 +74,7 @@ class UsageStatistics:
     InsertDrag, InsertMenu, Undo, Redo, Duplicate, Load \
         = list(ActionType)
 
-    def __init__(self, parent):
+    def __init__(self, parent=None):
         self.parent = parent
 
         self._actions = []
@@ -84,8 +84,6 @@ class UsageStatistics:
 
         self._action_type = ActionType.Unclassified
         self._metadata = None
-
-        UsageStatistics.statistics_sessions.append(self)
 
     @classmethod
     def is_enabled(cls) -> bool:
@@ -120,6 +118,19 @@ class UsageStatistics:
                 session.log_scheme(scheme)
             else:
                 session.drop_statistics()
+
+    @classmethod
+    def register_session(cls, session):
+        """
+        Register a session, effectively updating upon enabling/disabling statistics.
+        Upon enable, the open workflow is loaded.
+        Upon disable, the statistics session is cleared.
+
+        Parameters
+        ----------
+        session: UsageStatistics
+        """
+        cls.statistics_sessions.append(session)
 
     def begin_action(self, action_type):
         """


### PR DESCRIPTION
For purposes of backwards compatibility with versions of Orange3 (before the merging of https://github.com/biolab/orange3/pull/4190), where a `UsageStatistics` object is instantiated only to get the saved statistics file location.