### PR TITLE
[FIX] Preview: Do not render view box border

### DIFF
--- a/orangecanvas/canvas/scene.py
+++ b/orangecanvas/canvas/scene.py
@@ -932,6 +932,7 @@ def grab_svg(scene):
     painter = QPainter(gen)
 
     # Draw background.
+    painter.setPen(Qt.NoPen)
     painter.setBrush(scene.palette().base())
     painter.drawRect(target_rect)
 


### PR DESCRIPTION
#### Issue

The workflow previews in Recent/Examples workflows have a non-constant width border around them (depends on the overall scene size).

#### Changes

Do not draw view box rect outline in svg preview generation.

