### PR TITLE
addons: Restore default rst description parsing

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -217,6 +217,9 @@ def description_rich_text(item):  # type: (Item) -> str
         description = item.installable.description
         content_type = item.installable.description_content_type
 
+    if not content_type:
+        # if not defined try rst and fallback to plain text
+        content_type = "text/x-rst"
     try:
         html = markup.render_as_rich_text(description, content_type)
     except Exception:


### PR DESCRIPTION
#### Issue

Since gh-26 project descriptions in rst without declared 'description-content-type' render as plain text only.

Fixes gh-62

#### Changes

Try parsing as rst in case 'description-content-type' is not defined.