### PR TITLE
usagestatistics: Include launch count in statistics session

### DIFF
--- a/orangecanvas/document/usagestatistics.py
+++ b/orangecanvas/document/usagestatistics.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import List
 
-from AnyQt.QtCore import QCoreApplication
+from AnyQt.QtCore import QCoreApplication, QSettings
 
 from orangecanvas import config
 from orangecanvas.scheme import SchemeNode, SchemeLink, Scheme
@@ -412,6 +412,7 @@ class UsageStatistics:
             "Date": str(datetime.now().date()),
             "Application Version": QCoreApplication.applicationVersion(),
             "Operating System": platform.system() + " " + platform.release(),
+            "Launch Count": QSettings().value('startup/launch-count', 0, type=int),
             "Session": self._actions
         }
 


### PR DESCRIPTION
By including a launch count parameter in statistics sessions, it's possible to reliably distinguish new and old Orange users.

### How to test on Orange3

1. In `Orange/version.py`, set versions to `3.24.0` and `release = True`,
2. Open Orange, play around in canvas,
3. Close Orange,
4. Open Orange (statistics are sent upon start),

Statistics are stored in `/srv` on the service server.