### PR TITLE
[FIX] Double-click NodeItem when above a LinkItem

### DIFF
--- a/orangecanvas/canvas/items/linkitem.py
+++ b/orangecanvas/canvas/items/linkitem.py
@@ -17,7 +17,7 @@ from AnyQt.QtWidgets import (
 from AnyQt.QtGui import (
     QPen, QBrush, QColor, QPainterPath, QTransform, QPalette,
 )
-from AnyQt.QtCore import Qt, QPointF, QRectF, QLineF, QEvent, QPropertyAnimation
+from AnyQt.QtCore import Qt, QPointF, QRectF, QLineF, QEvent, QPropertyAnimation, Signal, QTimer
 
 from .nodeitem import AnchorPoint, SHADOW_COLOR
 from .utils import stroke_path
@@ -305,6 +305,8 @@ class LinkItem(QGraphicsWidget):
     central point (:func:`setSourceName`, :func:`setSinkName`)
 
     """
+    #: Signal emitted when the item has been activated (double-click)
+    activated = Signal()
 
     #: Z value of the item
     Z_VALUE = 0
@@ -609,6 +611,11 @@ class LinkItem(QGraphicsWidget):
                 self.sourceAnchor.setHoverState(state)
             self.curveItem.setHoverState(state)
             self.__updatePen()
+
+    def mouseDoubleClickEvent(self, event):
+        # type: (QGraphicsSceneMouseEvent) -> None
+        super().mouseDoubleClickEvent(event)
+        QTimer.singleShot(0, self.activated.emit)
 
     def hoverEnterEvent(self, event):
         # type: (QGraphicsSceneHoverEvent) -> None

--- a/orangecanvas/canvas/scene.py
+++ b/orangecanvas/canvas/scene.py
@@ -78,11 +78,14 @@ class CanvasScene(QGraphicsScene):
     #: Signal emitted when an :class:`NodeItem` has been double clicked.
     node_item_double_clicked = Signal(object)
 
-    #: An node item has been activated (clicked)
+    #: An node item has been activated (double-clicked)
     node_item_activated = Signal(object)
 
     #: An node item has been hovered
     node_item_hovered = Signal(object)
+
+    #: Link item has been activated (double-clicked)
+    link_item_activated = Signal(object)
 
     #: Link item has been hovered
     link_item_hovered = Signal(object)
@@ -131,6 +134,10 @@ class CanvasScene(QGraphicsScene):
         self.position_change_mapper = QSignalMapper(self)
         self.position_change_mapper.mapped[QObject].connect(
             self._on_position_change
+        )
+        self.link_activated_mapper = QSignalMapper(self)
+        self.link_activated_mapper.mapped[QObject].connect(
+            lambda node: self.link_item_activated.emit(node)
         )
 
     def clear_scene(self):  # type: () -> None
@@ -380,6 +387,7 @@ class CanvasScene(QGraphicsScene):
         self.activated_mapper.removeMappings(item)
         self.hovered_mapper.removeMappings(item)
         self.position_change_mapper.removeMappings(item)
+        self.link_activated_mapper.removeMappings(item)
 
         item.hide()
         self.removeItem(item)
@@ -417,6 +425,9 @@ class CanvasScene(QGraphicsScene):
         """
         Add a link (:class:`.LinkItem`) to the scene.
         """
+        self.link_activated_mapper.setMapping(item, item)
+        item.activated.connect(self.link_activated_mapper.map)
+
         if item.scene() is not self:
             self.addItem(item)
 

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -501,6 +501,7 @@ class SchemeEditWidget(QWidget):
             scene.set_registry(self.__registry)
         scene.focusItemChanged.connect(self.__onFocusItemChanged)
         scene.selectionChanged.connect(self.__onSelectionChanged)
+        scene.link_item_activated.connect(self.__onLinkActivate)
         scene.node_item_activated.connect(self.__onNodeActivate)
         scene.annotation_added.connect(self.__onAnnotationAdded)
         scene.annotation_removed.connect(self.__onAnnotationRemoved)
@@ -1393,16 +1394,6 @@ class SchemeEditWidget(QWidget):
             event.accept()
             return True
 
-        item = scene.item_at(event.scenePos(), items.LinkItem)
-
-        if item is not None and event.button() == Qt.LeftButton:
-            link = self.scene().link_for_item(item)
-            action = interactions.EditNodeLinksAction(self, link.source_node,
-                                                      link.sink_node)
-            action.edit_links()
-            event.accept()
-            return True
-
         return False
 
     def sceneKeyPressEvent(self, event):
@@ -1578,6 +1569,12 @@ class SchemeEditWidget(QWidget):
                                    priority=QuickHelpTipEvent.Permanent)
 
             QCoreApplication.sendEvent(self, ev)
+
+    def __onLinkActivate(self, item):
+        link = self.scene().link_for_item(item)
+        action = interactions.EditNodeLinksAction(self, link.source_node,
+                                                  link.sink_node)
+        action.edit_links()
 
     def __onNodeActivate(self, item):
         # type: (items.NodeItem) -> None


### PR DESCRIPTION
A double-click on a widget is caught by a NodeItem's `mouseDoubleClickEvent()`, mapped to the CanvasScene's `node_item_activated` signal, emitting a call to `__onNodeActivate` in the SchemeEditWidget.

Double-clicking a link was handled in SchemeEditWidget's `eventFilter()`, installed on the CanvasScene, which takes precedence over CanvasScene's and its children's events (i.e., NodeItem activate).

This PR implements an `activated` signal in LinkItem. The double-click now propagates according to the z-value of QGraphicsWidgets. In other words, NodeItem takes the event because it's above the LinkItem in the scene.