### PR TITLE
Tests: Remove quit timer from test fixtures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,4 +28,6 @@ build_script:
 
 test_script:
   - >-
+    %PYTHON%\python.exe -m pip list --format=freeze
+  - >-
     %PYTHON%\python.exe -m unittest discover -v .

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -961,9 +961,9 @@ class CanvasMainWindow(QMainWindow):
         margin = 20 if enabled else 0
 
         if self.dockWidgetArea(self.dock_widget) == Qt.LeftDockWidgetArea:
-            margins = (margin / 2, 0, margin, 0)
+            margins = (margin // 2, 0, margin, 0)
         else:
-            margins = (margin, 0, margin / 2, 0)
+            margins = (margin, 0, margin // 2, 0)
 
         central.layout().setContentsMargins(*margins)
 

--- a/orangecanvas/application/tests/test_canvastooldock.py
+++ b/orangecanvas/application/tests/test_canvastooldock.py
@@ -44,7 +44,7 @@ class TestCanvasDockWidget(test.QAppTestCase):
         dock.setCollapsedWidget(toolbar)
 
         dock.show()
-        self.app.exec_()
+        self.qWait()
 
     def test_canvas_tool_dock(self):
         reg = registry_tests.small_testing_registry()
@@ -54,7 +54,7 @@ class TestCanvasDockWidget(test.QAppTestCase):
         dock.toolbox.setModel(reg.model())
 
         dock.show()
-        self.app.exec_()
+        self.qWait()
 
     def test_splitter_resizer(self):
         w = QSplitter(orientation=Qt.Vertical)
@@ -71,10 +71,12 @@ class TestCanvasDockWidget(test.QAppTestCase):
                 resizer.close()
 
         w.show()
-        timer = QTimer(resizer, interval=1000)
+        timer = QTimer(resizer, interval=100)
         timer.timeout.connect(toogle)
         timer.start()
-        self.app.exec_()
+        toogle()
+        self.qWait()
+        timer.stop()
 
     def test_category_toolbar(self):
         reg = registry_tests.small_testing_registry()
@@ -83,8 +85,7 @@ class TestCanvasDockWidget(test.QAppTestCase):
         w = QuickCategoryToolbar()
         w.setModel(reg.model())
         w.show()
-
-        self.app.exec_()
+        self.qWait()
 
 
 class TestPopupMenu(test.QAppTestCase):
@@ -96,4 +97,5 @@ class TestPopupMenu(test.QAppTestCase):
         w = CategoryPopupMenu()
         w.setModel(model)
         w.setRootIndex(model.index(0, 0))
-        w.exec_()
+        w.show()
+        self.qWait()

--- a/orangecanvas/application/tests/test_outputview.py
+++ b/orangecanvas/application/tests/test_outputview.py
@@ -38,12 +38,13 @@ class TestOutputView(QAppTestCase):
             text = output.toPlainText()
             self.assertLessEqual(len(text.splitlines()), 5)
 
-        timer = QTimer(output, interval=500)
+        timer = QTimer(output, interval=25)
         timer.timeout.connect(advance)
         timer.start()
-        self.app.exec_()
+        self.qWait(100)
+        timer.stop()
 
-    def test_formated(self):
+    def test_formatted(self):
         output = OutputView()
         output.show()
 
@@ -56,8 +57,7 @@ class TestOutputView(QAppTestCase):
 
         bold = output.formatted(weight=100, underline=True)
         bold.write("Shutup")
-
-        self.app.exec_()
+        self.qWait()
 
     def test_threadsafe(self):
         output = OutputView()
@@ -101,9 +101,7 @@ class TestOutputView(QAppTestCase):
 
         pool = multiprocessing.pool.ThreadPool(100)
         res = pool.map_async(printer, range(10000))
-
-        self.app.exec_()
-
+        self.qWait()
         res.wait()
 
         # force all pending enqueued emits
@@ -138,7 +136,5 @@ class TestOutputView(QAppTestCase):
 
         pool = multiprocessing.pool.ThreadPool(10)
         res = pool.map_async(raise_exception, range(100))
-
-        self.app.exec_()
-
+        self.qWait(100)
         res.wait()

--- a/orangecanvas/application/tests/test_outputview.py
+++ b/orangecanvas/application/tests/test_outputview.py
@@ -111,6 +111,7 @@ class TestOutputView(QAppTestCase):
 
         self.assertTrue(all(correct))
         self.assertEqual(len(correct), 10000)
+        pool.close()
 
     def test_excepthook(self):
         output = OutputView()
@@ -138,3 +139,4 @@ class TestOutputView(QAppTestCase):
         res = pool.map_async(raise_exception, range(100))
         self.qWait(100)
         res.wait()
+        pool.close()

--- a/orangecanvas/application/tests/test_schemeinfo.py
+++ b/orangecanvas/application/tests/test_schemeinfo.py
@@ -8,11 +8,10 @@ class TestSchemeInfo(test.QAppTestCase):
         scheme = Scheme(title="A Scheme", description="A String\n")
         dialog = SchemeInfoDialog()
         dialog.setScheme(scheme)
-
+        self.singleShot(10, dialog.close)
         status = dialog.exec_()
-
         if status == dialog.Accepted:
-            self.assertEqual(scheme.title.strip(),
-                             dialog.editor.name_edit.text().strip())
+            self.assertEqual(scheme.title,
+                             dialog.editor.name_edit.text())
             self.assertEqual(scheme.description,
-                             dialog.editor.desc_edit.toPlainText().strip())
+                             dialog.editor.desc_edit.toPlainText())

--- a/orangecanvas/application/tests/test_settings.py
+++ b/orangecanvas/application/tests/test_settings.py
@@ -23,7 +23,7 @@ class TestUserSettings(test.QAppTestCase):
         settings = UserSettingsDialog()
         settings.show()
 
-        self.app.exec_()
+        self.qWait()
         registry.set_global_registry(None)
 
     def test_settings_model(self):
@@ -45,7 +45,7 @@ class TestUserSettings(test.QAppTestCase):
         view.setModel(model)
 
         view.show()
-        self.app.exec_()
+        self.qWait()
 
     def test_conda_checkbox(self):
         """

--- a/orangecanvas/application/tests/test_welcomedialog.py
+++ b/orangecanvas/application/tests/test_welcomedialog.py
@@ -31,9 +31,10 @@ class TestDialog(QAppTestCase):
         action = [None]
 
         def p(a):
-            print(str(a.text()))
             action[0] = a
 
         d.triggered.connect(p)
-        self.app.exec_()
+        self.singleShot(0, action1.trigger)
+        self.qWait()
         self.assertIs(action[0], d.triggeredAction())
+        self.assertIs(action[0], action1)

--- a/orangecanvas/application/tests/test_widgettoolbox.py
+++ b/orangecanvas/application/tests/test_widgettoolbox.py
@@ -47,7 +47,7 @@ class TestWidgetToolBox(test.QAppTestCase):
         # Test order of buttons
         grid_layout = grid.layout()
         for i in range(len(actions)):
-            button = grid_layout.itemAtPosition(i / 4, i % 4).widget()
+            button = grid_layout.itemAtPosition(i // 4, i % 4).widget()
             self.assertIs(button.defaultAction(), actions[i])
 
         grid.actionTriggered.connect(triggered_actions2.append)

--- a/orangecanvas/application/tests/test_widgettoolbox.py
+++ b/orangecanvas/application/tests/test_widgettoolbox.py
@@ -57,8 +57,7 @@ class TestWidgetToolBox(test.QAppTestCase):
         w.setLayout(layout)
         w.show()
         one_action.trigger()
-
-        self.app.exec_()
+        self.qWait()
 
     def test_toolbox(self):
 
@@ -91,4 +90,4 @@ class TestWidgetToolBox(test.QAppTestCase):
         box.setTabButtonHeight(40)
         box.setTabIconSize(QSize(30, 30))
 
-        self.app.exec_()
+        self.qWait()

--- a/orangecanvas/canvas/items/tests/test_annotationitem.py
+++ b/orangecanvas/canvas/items/tests/test_annotationitem.py
@@ -34,8 +34,7 @@ class TestAnnotationItem(TestItems):
         annot._TextAnnotation__textItem.setFocus()
         self.scene.addItem(annot)
         self.scene.addItem(annot2)
-
-        self.app.exec_()
+        self.qWait()
 
     def test_arrowannotation(self):
         item = ArrowItem()
@@ -64,4 +63,5 @@ class TestAnnotationItem(TestItems):
         timer = QTimer(item, interval=10)
         timer.timeout.connect(advance)
         timer.start()
-        self.app.exec_()
+        self.qWait()
+        timer.stop()

--- a/orangecanvas/canvas/items/tests/test_annotationitem.py
+++ b/orangecanvas/canvas/items/tests/test_annotationitem.py
@@ -58,7 +58,7 @@ class TestAnnotationItem(TestItems):
         def advance():
             clock = time.process_time() * 10
             item.setLineWidth(5 + math.sin(clock) * 5)
-            item.setColor(QColor(Qt.red).lighter(100 + 30 * math.cos(clock)))
+            item.setColor(QColor(Qt.red).lighter(100 + int(30 * math.cos(clock))))
 
         timer = QTimer(item, interval=10)
         timer.timeout.connect(advance)

--- a/orangecanvas/canvas/items/tests/test_controlpoints.py
+++ b/orangecanvas/canvas/items/tests/test_controlpoints.py
@@ -34,7 +34,7 @@ class TestControlPoints(TestItems):
         control.rectEdited.connect(rect.setRect)
 
         self.view.show()
-        self.app.exec_()
+        self.qWait()
 
         self.assertEqual(rect.rect(), control.rect())
 
@@ -56,6 +56,6 @@ class TestControlPoints(TestItems):
         control.lineEdited.connect(line.setLine)
 
         self.view.show()
-        self.app.exec_()
+        self.qWait()
 
         self.assertEqual(control.line(), line.line())

--- a/orangecanvas/canvas/items/tests/test_graphicspathobject.py
+++ b/orangecanvas/canvas/items/tests/test_graphicspathobject.py
@@ -63,7 +63,7 @@ class TestGraphicsPathObject(TestItems):
         self.scene.addItem(obj)
         self.view.show()
 
-        self.app.exec_()
+        self.qWait()
 
     def test_shapeFromPath(self):
         path = QPainterPath()

--- a/orangecanvas/canvas/items/tests/test_linkitem.py
+++ b/orangecanvas/canvas/items/tests/test_linkitem.py
@@ -88,7 +88,7 @@ class TestLinkItem(TestItems):
         self.assertTrue(len(negate_item.inputAnchors()) == 1)
         self.assertTrue(len(one_item.outputAnchors()) == 1)
 
-        self.app.exec_()
+        self.qWait()
 
     def test_dynamic_link(self):
         link = LinkItem()
@@ -121,4 +121,5 @@ class TestLinkItem(TestItems):
         timer = QTimer(link, interval=0)
         timer.timeout.connect(advance)
         timer.start()
-        self.app.exec_()
+        self.qWait()
+        timer.stop()

--- a/orangecanvas/canvas/items/tests/test_nodeitem.py
+++ b/orangecanvas/canvas/items/tests/test_nodeitem.py
@@ -81,7 +81,7 @@ class TestNodeItem(TestItems):
         nb_item.setProcessingState(1)
 
         def progress():
-            p = (nb_item.progress() + 1) % 100
+            p = (nb_item.progress() + 25) % 100
             nb_item.setProgress(p)
 
             if p > 50:
@@ -93,11 +93,11 @@ class TestNodeItem(TestItems):
 
             negate_item.setAnchorRotation(50 - p)
 
-        timer = QTimer(nb_item, interval=10)
+        timer = QTimer(nb_item, interval=5)
         timer.start()
         timer.timeout.connect(progress)
-
-        self.app.exec_()
+        self.qWait()
+        timer.stop()
 
     def test_nodeanchors(self):
         one_item = NodeItem()
@@ -126,7 +126,7 @@ class TestNodeItem(TestItems):
         anchor = one_item.newOutputAnchor()
         self.assertIsInstance(anchor, AnchorPoint)
 
-        self.app.exec_()
+        self.qWait()
 
     def test_anchoritem(self):
         anchoritem = NodeAnchorItem(None)
@@ -167,8 +167,9 @@ class TestNodeItem(TestItems):
             t = [(t + 0.05) % 1.0 for t in t]
             anchoritem.setAnchorPositions(t)
 
-        timer = QTimer(anchoritem, interval=20)
+        timer = QTimer(anchoritem, interval=10)
         timer.start()
         timer.timeout.connect(advance)
 
-        self.app.exec_()
+        self.qWait()
+        timer.stop()

--- a/orangecanvas/canvas/tests/test_layout.py
+++ b/orangecanvas/canvas/tests/test_layout.py
@@ -76,10 +76,11 @@ class TestAnchorLayout(QAppTestCase):
             cons_item.setPos(path.pointAtPercent(t % 1.0))
             negate_item.setPos(path.pointAtPercent((t + 0.5) % 1.0))
 
-        timer = QTimer(negate_item, interval=20)
+        timer = QTimer(negate_item, interval=5)
         timer.start()
         timer.timeout.connect(advance)
-        self.app.exec_()
+        self.qWait()
+        timer.stop()
 
     def widget_desc(self):
         reg = small_testing_registry()

--- a/orangecanvas/canvas/tests/test_scene.py
+++ b/orangecanvas/canvas/tests/test_scene.py
@@ -87,7 +87,7 @@ class TestScene(QAppTestCase):
         self.assertTrue(one_item.outputAnchors())
         self.assertTrue(negate_item.inputAnchors())
 
-        self.app.exec_()
+        self.qWait()
 
     def test_scene_with_scheme(self):
         """Test scene through modifying the scheme.
@@ -145,7 +145,7 @@ class TestScene(QAppTestCase):
         test_scheme.add_link(link1)
         self.assertTrue(len(self.scene.link_items()) == 1)
         self.assertSequenceEqual(self.scene.link_items(), link_items)
-        self.app.exec_()
+        self.qWait()
 
     def test_scheme_construction(self):
         """Test construction (editing) of the scheme through the scene.
@@ -225,7 +225,7 @@ class TestScene(QAppTestCase):
         self.assertSequenceEqual(test_scheme.links,
                                  [link1, link2])
 
-        self.app.exec_()
+        self.qWait()
 
     def widget_desc(self):
         reg = small_testing_registry()

--- a/orangecanvas/document/tests/test_editlinksdialog.py
+++ b/orangecanvas/document/tests/test_editlinksdialog.py
@@ -28,6 +28,8 @@ class TestLinksEditDialog(test.QAppTestCase):
         dlg.setLinks(links)
 
         self.assertSequenceEqual(dlg.links(), links)
+        self.singleShot(50, dlg.close)
+
         status = dlg.exec_()
 
         self.assertTrue(dlg.links() == [] or dlg.links() == links)
@@ -42,7 +44,7 @@ class TestLinksEditDialog(test.QAppTestCase):
         view.show()
         view.resize(400, 300)
 
-        self.app.exec_()
+        self.qWait()
 
     def test_editlinksnode(self):
         reg = small_testing_registry()
@@ -65,4 +67,4 @@ class TestLinksEditDialog(test.QAppTestCase):
 
         view.show()
         view.resize(800, 300)
-        self.app.exec_()
+        self.qWait()

--- a/orangecanvas/document/tests/test_quickmenu.py
+++ b/orangecanvas/document/tests/test_quickmenu.py
@@ -33,8 +33,7 @@ class TestMenu(QAppTestCase):
 
         menu.popup(QPoint(200, 200))
         menu.activateWindow()
-
-        self.app.exec_()
+        self.qWait()
 
     def test_menu_with_registry(self):
         registry = QtWidgetRegistry(small_testing_registry())
@@ -57,6 +56,7 @@ class TestMenu(QAppTestCase):
         menu.hovered.connect(hovered)
         self.app.setActiveWindow(menu)
 
+        self.singleShot(100, menu.close)
         rval = menu.exec_(QPoint(200, 200))
 
         if triggered_action:

--- a/orangecanvas/document/tests/test_schemeedit.py
+++ b/orangecanvas/document/tests/test_schemeedit.py
@@ -235,6 +235,7 @@ class TestSchemeEdit(QAppTestCase):
         node = SchemeNode(
             self.reg.widget("one"), title="title1", position=(10000, 100))
         self.w.addNode(node)
+        w.setFixedSize(300, 300)
         w.show()
         assert QTest.qWaitForWindowExposed(w, 500)
         w.ensureVisible(node)

--- a/orangecanvas/gui/test.py
+++ b/orangecanvas/gui/test.py
@@ -11,6 +11,8 @@ from AnyQt.QtCore import QCoreApplication, QTimer, QStandardPaths, QPoint, Qt
 from AnyQt.QtGui import QMouseEvent
 from AnyQt.QtTest import QTest
 
+DEFAULT_TIMEOUT = 50
+
 
 class QCoreAppTestCase(unittest.TestCase):
     _AppClass = QCoreApplication
@@ -34,14 +36,8 @@ class QCoreAppTestCase(unittest.TestCase):
 
     def setUp(self):
         super(QCoreAppTestCase, self).setUp()
-        self._quittimer = QTimer(interval=100)
-        self._quittimer.timeout.connect(self.app.quit)
-        self._quittimer.start()
 
     def tearDown(self):
-        self._quittimer.stop()
-        self._quittimer.timeout.disconnect(self.app.quit)
-        self._quittimer = None
         super(QCoreAppTestCase, self).tearDown()
 
     @classmethod
@@ -53,14 +49,14 @@ class QCoreAppTestCase(unittest.TestCase):
         super(QCoreAppTestCase, cls).tearDownClass()
         QStandardPaths.setTestModeEnabled(False)
 
+    @classmethod
+    def qWait(cls, timeout=DEFAULT_TIMEOUT):
+        QTest.qWait(timeout)
+
 
 class QAppTestCase(QCoreAppTestCase):
     _AppClass = QApplication
     app = None  # type: QApplication
-
-    def tearDown(self):
-        QTest.qWait(10)
-        super(QAppTestCase, self).tearDown()
 
 
 def mouseMove(widget, buttons, modifier=Qt.NoModifier, pos=QPoint(), delay=-1):

--- a/orangecanvas/gui/test.py
+++ b/orangecanvas/gui/test.py
@@ -3,8 +3,8 @@ Basic Qt testing framework
 ==========================
 """
 import unittest
-
 import gc
+from typing import Callable, Any
 
 from AnyQt.QtWidgets import QApplication, QWidget
 from AnyQt.QtCore import QCoreApplication, QTimer, QStandardPaths, QPoint, Qt
@@ -52,6 +52,10 @@ class QCoreAppTestCase(unittest.TestCase):
     @classmethod
     def qWait(cls, timeout=DEFAULT_TIMEOUT):
         QTest.qWait(timeout)
+
+    @classmethod
+    def singleShot(cls, timeout: int, slot: 'Callable[[], Any]'):
+        QTimer.singleShot(timeout, slot)
 
 
 class QAppTestCase(QCoreAppTestCase):

--- a/orangecanvas/gui/tests/test_dock.py
+++ b/orangecanvas/gui/tests/test_dock.py
@@ -34,11 +34,11 @@ class TestDock(test.QAppTestCase):
         dock.setExpanded(True)
         dock.setExpanded(False)
 
-        timer = QTimer(dock, interval=200)
+        timer = QTimer(dock, interval=50)
         timer.timeout.connect(lambda: dock.setExpanded(not dock.expanded()))
         timer.start()
-
-        # self.app.exec_()
+        self.qWait()
+        timer.stop()
 
     def test_dock_mainwinow(self):
         mw = QMainWindow()
@@ -55,8 +55,8 @@ class TestDock(test.QAppTestCase):
         mw.setCentralWidget(QTextEdit())
         mw.show()
 
-        timer = QTimer(dock, interval=200)
+        timer = QTimer(dock, interval=50)
         timer.timeout.connect(lambda: dock.setExpanded(not dock.expanded()))
         timer.start()
-
-        # self.app.exec_()
+        self.qWait()
+        timer.stop()

--- a/orangecanvas/gui/tests/test_dropshadow.py
+++ b/orangecanvas/gui/tests/test_dropshadow.py
@@ -100,7 +100,8 @@ class TestDropShadow(test.QAppTestCase):
         )
         @oanim.valueChanged.connect
         def _(value):
-            f.setOffset(QPoint(15 * math.cos(value), 15 * math.sin(value)))
+            f.setOffset(QPoint(int(15 * math.cos(value)),
+                               int(15 * math.sin(value))))
         oanim.start()
         w.show()
         self.qWait()

--- a/orangecanvas/gui/tests/test_dropshadow.py
+++ b/orangecanvas/gui/tests/test_dropshadow.py
@@ -46,7 +46,7 @@ class TestDropShadow(test.QAppTestCase):
             duration=3000
         )
         ranim.start()
-        self.app.exec_()
+        self.qWait()
 
     def test1(self):
         class FT(QToolBar):
@@ -84,7 +84,7 @@ class TestDropShadow(test.QAppTestCase):
             duration=3000
         )
         ranim.start()
-        self.app.exec_()
+        self.qWait()
 
     def test_offset(self):
         w = QWidget()
@@ -103,7 +103,7 @@ class TestDropShadow(test.QAppTestCase):
             f.setOffset(QPoint(15 * math.cos(value), 15 * math.sin(value)))
         oanim.start()
         w.show()
-        self.app.exec_()
+        self.qWait()
 
 
 if __name__ == "__main__":

--- a/orangecanvas/gui/tests/test_framelesswindow.py
+++ b/orangecanvas/gui/tests/test_framelesswindow.py
@@ -8,11 +8,13 @@ class TestFramelessWindow(QAppTestCase):
     def test_framelesswindow(self):
         window = FramelessWindow()
         window.show()
+        window.setRadius(5)
 
         def cycle():
             window.setRadius((window.radius() + 3) % 30)
 
-        timer = QTimer(window, interval=250)
+        timer = QTimer(window, interval=50)
         timer.timeout.connect(cycle)
         timer.start()
-        self.app.exec_()
+        self.qWait()
+        timer.stop()

--- a/orangecanvas/gui/tests/test_lineedit.py
+++ b/orangecanvas/gui/tests/test_lineedit.py
@@ -47,4 +47,4 @@ class TestSearchWidget(QAppTestCase):
 
         b = line.button(LineEdit.RightPosition)
         b.setFlat(False)
-        self.app.exec_()
+        self.qWait()

--- a/orangecanvas/gui/tests/test_splashscreen.py
+++ b/orangecanvas/gui/tests/test_splashscreen.py
@@ -45,5 +45,5 @@ class TestSplashScreen(QAppTestCase):
         timer = QTimer(w, interval=1)
         timer.timeout.connect(advance_time)
         timer.start()
-
-        self.app.exec_()
+        self.qWait()
+        timer.stop()

--- a/orangecanvas/gui/tests/test_stackedwidget.py
+++ b/orangecanvas/gui/tests/test_stackedwidget.py
@@ -55,8 +55,7 @@ class TestStackedWidget(test.QAppTestCase):
                                  widgets())
 
         stack.setCurrentIndex(1)
-        # wait until animation finished
-        self.app.exec_()
+        self.qWait()
 
         self.assertEqual(stack.currentIndex(), 1)
 
@@ -76,4 +75,5 @@ class TestStackedWidget(test.QAppTestCase):
         timer = QTimer(stack, interval=1000)
         timer.timeout.connect(toogle)
         timer.start()
-        self.app.exec_()
+        self.qWait()
+        timer.stop()

--- a/orangecanvas/gui/tests/test_toolbar.py
+++ b/orangecanvas/gui/tests/test_toolbar.py
@@ -40,7 +40,6 @@ class ToolBoxTest(test.QAppTestCase):
                                  msg="insertAction does not preserve "
                                      "action order")
 
-        # self.singleShot(2000, lambda: w.setOrientation(Qt.Vertical))
-        # self.singleShot(5000, lambda: w.removeAction(actions[1]))
-
-        self.app.exec_()
+        self.singleShot(10, lambda: w.setOrientation(Qt.Vertical))
+        self.singleShot(50, lambda: w.removeAction(actions[1]))
+        self.qWait()

--- a/orangecanvas/gui/tests/test_toolbox.py
+++ b/orangecanvas/gui/tests/test_toolbox.py
@@ -51,7 +51,7 @@ class TestToolBox(test.QAppTestCase):
         self.assertIs(w.widget(2), p3)
         self.assertIs(w.widget(3), p4)
 
-        self.app.exec_()
+        self.qWait()
 
     def test_tool_box_exclusive(self):
         w = toolbox.ToolBox()

--- a/orangecanvas/gui/tests/test_toolgrid.py
+++ b/orangecanvas/gui/tests/test_toolgrid.py
@@ -95,4 +95,4 @@ class TestToolGrid(test.QAppTestCase):
         action_a.trigger()
 
         w.show()
-        self.app.exec_()
+        self.qWait()

--- a/orangecanvas/gui/tests/test_tooltree.py
+++ b/orangecanvas/gui/tests/test_tooltree.py
@@ -41,7 +41,7 @@ class TestToolTree(QAppTestCase):
 
         tree.show()
 
-        self.app.exec_()
+        self.qWait()
 
     def test_tooltree_registry(self):
         reg = QtWidgetRegistry(small_testing_registry())
@@ -56,7 +56,7 @@ class TestToolTree(QAppTestCase):
 
         tree.triggered.connect(p)
 
-        self.app.exec_()
+        self.qWait()
 
     def test_flattened(self):
         reg = QtWidgetRegistry(small_testing_registry())
@@ -98,4 +98,4 @@ class TestToolTree(QAppTestCase):
 
         tree.triggered.connect(p)
 
-        self.app.exec_()
+        self.qWait()

--- a/orangecanvas/preview/tests/test_previewbrowser.py
+++ b/orangecanvas/preview/tests/test_previewbrowser.py
@@ -41,4 +41,4 @@ class TestPreviewBrowser(test.QAppTestCase):
             print(index)
 
         w.currentIndexChanged.connect(p)
-        self.app.exec_()
+        self.qWait()

--- a/orangecanvas/preview/tests/test_previewdialog.py
+++ b/orangecanvas/preview/tests/test_previewdialog.py
@@ -18,6 +18,7 @@ class TestPreviewDialog(test.QAppTestCase):
 
         current = [None]
         w.currentIndexChanged.connect(current.append)
+        self.singleShot(50, w.close)
         status = w.exec_()
 
         if status and len(current) > 1:
@@ -25,6 +26,7 @@ class TestPreviewDialog(test.QAppTestCase):
 
         w.setItems(["A", "B"])
         w.show()
+        self.singleShot(50, w.close)
         status = w.exec_()
         if status:
             self.assertTrue(w.currentIndex() != -1)

--- a/orangecanvas/utils/tests/test_propertybindings.py
+++ b/orangecanvas/utils/tests/test_propertybindings.py
@@ -124,7 +124,7 @@ class Test(test.QAppTestCase):
         w.setLayout(layout)
         w.show()
 
-        self.app.exec_()
+        self.qWait()
 
     def test_expr(self):
         obj1 = QObject()


### PR DESCRIPTION
#### Issue

Tests use a bad practice w.r.t calling app.exec and expect that a quit timer defined in the base text fixture will quit the event loop.

#### Changes

* remove quit timer from base QCoreAppTest case
* update tests accordingly
* while here also: 
   - fix warnings due to unclosed multiprocessing.pool.ThreadPool
   - fix warnings from implicit conversion to int in the tests (visible running on Python 3.8)
