### PR TITLE
Fix node selection when the node is in front of a link anchor

### DIFF
--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -302,6 +302,7 @@ class LinkAnchorIndicator(QGraphicsEllipseItem):
     def __init__(self, parent=None):
         # type: (Optional[QGraphicsItem]) -> None
         super().__init__(parent)
+        self.setAcceptedMouseButtons(Qt.NoButton)
         self.setRect(-3.5, -3.5, 7., 7.)
         self.setPen(QPen(Qt.NoPen))
         self.setBrush(QBrush(QColor("#9CACB4")))

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1270,7 +1270,8 @@ class SchemeEditWidget(QWidget):
 
         pos = event.scenePos()
 
-        anchor_item = scene.item_at(pos, items.NodeAnchorItem)
+        anchor_item = scene.item_at(
+            pos, items.NodeAnchorItem, buttons=Qt.LeftButton)
         if anchor_item and event.button() == Qt.LeftButton:
             # Start a new link starting at item
             scene.clearSelection()


### PR DESCRIPTION
#### Issue

Since gh-28 mouse click on a node would not work if a another node's anchor was behind it.

#### Changes

* Use `buttons` parameter to query the NodeAnchorItem
* Disable all mouse buttons on LinkAnchorIndicator
