### PR TITLE
[ENH] Add Annotations:  Cancel on escape key

### DIFF
--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -1157,6 +1157,7 @@ class NewArrowAnnotation(UserInteraction):
         self.arrow_item = None  # type: Optional[items.ArrowAnnotation]
         self.annotation = None  # type: Optional[scheme.SchemeArrowAnnotation]
         self.color = "red"
+        self.cancelOnEsc = True
 
     def start(self):
         # type: () -> None
@@ -1237,6 +1238,12 @@ class NewArrowAnnotation(UserInteraction):
         else:
             return super().mouseReleaseEvent(event)
 
+    def cancel(self, reason=UserInteraction.OtherReason):  # type: (int) -> None
+        if self.arrow_item is not None:
+            self.scene.removeItem(self.arrow_item)
+            self.arrow_item = None
+        super().cancel(reason)
+
     def end(self):
         # type: () -> None
         self.down_pos = None
@@ -1271,6 +1278,7 @@ class NewTextAnnotation(UserInteraction):
         self.annotation = None  # type: Optional[scheme.SchemeTextAnnotation]
         self.control = None  # type: Optional[controlpoints.ControlPointRect]
         self.font = document.font()  # type: QFont
+        self.cancelOnEsc = True
 
     def setFont(self, font):
         # type: (QFont) -> None
@@ -1386,6 +1394,13 @@ class NewTextAnnotation(UserInteraction):
         rect = QRectF(QPointF(point.x(), point.y() - spacing - margin),
                       QSizeF(150, spacing + 2 * margin))
         return rect
+
+    def cancel(self, reason=UserInteraction.OtherReason):  # type: (int) -> None
+        if self.annotation_item is not None:
+            self.annotation_item.clearFocus()
+            self.scene.removeItem(self.annotation_item)
+            self.annotation_item = None
+        super().cancel(reason)
 
     def end(self):
         # type: () -> None

--- a/orangecanvas/document/tests/test_schemeedit.py
+++ b/orangecanvas/document/tests/test_schemeedit.py
@@ -207,6 +207,26 @@ class TestSchemeEdit(QAppTestCase):
         self.assertEqual(len(workflow.annotations), 1)
         self.assertIsInstance(workflow.annotations[0], SchemeArrowAnnotation)
 
+    def test_arrow_annotation_action_cancel(self):
+        w = self.w
+        workflow = w.scheme()
+        view = w.view()
+        w.resize(300, 300)
+        actions = w.toolbarActions()
+        action = action_by_name(actions, "new-arrow-action")
+        action.trigger()
+        self.assertTrue(action.isChecked())
+        # cancel immediately after activating
+        QTest.keyClick(view.viewport(), Qt.Key_Escape)
+        self.assertFalse(action.isChecked())
+        action.trigger()
+        # cancel after mouse press and drag
+        QTest.mousePress(view.viewport(), Qt.LeftButton, pos=QPoint(50, 50))
+        mouseMove(view.viewport(), Qt.LeftButton, pos=QPoint(100, 100))
+        QTest.keyClick(view.viewport(), Qt.Key_Escape)
+        self.assertFalse(action.isChecked())
+        self.assertEqual(workflow.annotations, [])
+
     def test_text_annotation_action(self):
         w = self.w
         workflow = w.scheme()
@@ -223,6 +243,27 @@ class TestSchemeEdit(QAppTestCase):
 
         self.assertEqual(len(workflow.annotations), 1)
         self.assertIsInstance(workflow.annotations[0], SchemeTextAnnotation)
+
+    def test_text_annotation_action_cancel(self):
+        w = self.w
+        workflow = w.scheme()
+        view = w.view()
+        w.resize(300, 300)
+        actions = w.toolbarActions()
+        action = action_by_name(actions, "new-text-action")
+        action.trigger()
+        self.assertTrue(action.isChecked())
+        # cancel immediately after activating
+        QTest.keyClick(view.viewport(), Qt.Key_Escape)
+        self.assertFalse(action.isChecked())
+        action.trigger()
+        # cancel after mouse press and drag
+        QTest.mousePress(view.viewport(), Qt.LeftButton, pos=QPoint(50, 50))
+        mouseMove(view.viewport(), Qt.LeftButton, pos=QPoint(100, 100))
+        QTest.keyClick(view.viewport(), Qt.Key_Escape)
+        self.assertFalse(action.isChecked())
+        w.scene().setFocusItem(None)
+        self.assertEqual(workflow.annotations, [])
 
     def test_path(self):
         w = self.w


### PR DESCRIPTION
#### Issue

Add text/arrow annotations should support 'cancel on escape key'

#### Changes

Enable and implement cancel operations on 'Add Text/Arrow annotation' interaction handlers.

