### PR TITLE
[ENH] Crash recovery

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1042,6 +1042,8 @@ class CanvasMainWindow(QMainWindow):
         Create and show a new CanvasMainWindow instance.
         """
         newwindow = self.create_new_window()
+        newwindow.load_swp()
+
         newwindow.raise_()
         newwindow.show()
         newwindow.activateWindow()

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1477,6 +1477,7 @@ class CanvasMainWindow(QMainWindow):
         if filename:
             settings.setValue("last-scheme-dir", os.path.dirname(filename))
             if self.save_scheme_to(curr_scheme, filename):
+                self.clear_swp()
                 document.setPath(filename)
                 document.setModified(False)
                 self.add_recent_scheme(curr_scheme.title, document.path())
@@ -2180,6 +2181,8 @@ class CanvasMainWindow(QMainWindow):
                 # Reject the event
                 event.ignore()
                 return
+
+        self.clear_swp()
 
         old_scheme = document.scheme()
 

--- a/orangecanvas/application/tests/test_mainwindow.py
+++ b/orangecanvas/application/tests/test_mainwindow.py
@@ -29,6 +29,7 @@ class TestMainWindowBase(QAppTestCase):
         self.w.set_widget_registry(self.registry)
 
     def tearDown(self):
+        self.w.clear_swp()
         self.w.deleteLater()
         for w in MainWindow._instances:
             w.deleteLater()

--- a/orangecanvas/document/commands.py
+++ b/orangecanvas/document/commands.py
@@ -17,9 +17,70 @@ if typing.TYPE_CHECKING:
     Line = Tuple[Pos, Pos]
 
 
-class AddNodeCommand(QUndoCommand):
+class UndoCommand(QUndoCommand):
+    """
+    For pickling
+    """
+    def __init__(self, text, parent=None):
+        QUndoCommand.__init__(self, text, parent)
+        self.__parent = parent
+        self.__initialized = True
+
+        # defined and initialized in __setstate__
+        # self.__child_states = {}
+        # self.__children = []
+
+    def __getstate__(self):
+        return {
+            **{k: v for k, v in self.__dict__.items()},
+            '_UndoCommand__initialized': False,
+            '_UndoCommand__text': self.text(),
+            '_UndoCommand__children':
+                [self.child(i) for i in range(self.childCount())]
+        }
+
+    def __setstate__(self, state):
+        if hasattr(self, '_UndoCommand__initialized') and \
+                self.__initialized:
+            return
+
+        text = state['_UndoCommand__text']
+        parent = state['_UndoCommand__parent']  # type: UndoCommand
+
+        if parent is not None and \
+                (not hasattr(parent, '_UndoCommand__initialized') or
+                 not parent.__initialized):
+            # will be initialized in parent's __setstate__
+            if not hasattr(parent, '_UndoCommand__child_states'):
+                setattr(parent, '_UndoCommand__child_states', {})
+            parent.__child_states[self] = state
+            return
+
+        # init must be called on unpickle-time to recreate Qt object
+        UndoCommand.__init__(self, text, parent)
+        for child in state['_UndoCommand__children']:
+            child.__setstate__(self.__child_states[child])
+
+        self.__dict__ = {k: v for k, v in state.items()}
+
+    @staticmethod
+    def from_QUndoCommand(qc: QUndoCommand, parent=None):
+        if type(qc) == QUndoCommand:
+            qc.__class__ = UndoCommand
+            qc.__initialized = True
+
+        qc.__parent = parent
+
+        children = [qc.child(i) for i in range(qc.childCount())]
+        for child in children:
+            UndoCommand.from_QUndoCommand(child, parent=qc)
+
+        return qc
+
+
+class AddNodeCommand(UndoCommand):
     def __init__(self, scheme, node, parent=None):
-        # type: (Scheme, SchemeNode, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeNode, Optional[UndoCommand]) -> None
         super().__init__("Add %s" % node.title, parent)
         self.scheme = scheme
         self.node = node
@@ -31,15 +92,15 @@ class AddNodeCommand(QUndoCommand):
         self.scheme.remove_node(self.node)
 
 
-class RemoveNodeCommand(QUndoCommand):
+class RemoveNodeCommand(UndoCommand):
     def __init__(self, scheme, node, parent=None):
-        # type: (Scheme, SchemeNode, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeNode, Optional[UndoCommand]) -> None
         super().__init__("Remove %s" % node.title, parent)
         self.scheme = scheme
         self.node = node
 
-        links = scheme.input_links(node) + \
-                scheme.output_links(node)
+        links = scheme.input_links(self.node) + \
+                scheme.output_links(self.node)
 
         for link in links:
             RemoveLinkCommand(scheme, link, parent=self)
@@ -55,9 +116,9 @@ class RemoveNodeCommand(QUndoCommand):
         super().undo()
 
 
-class AddLinkCommand(QUndoCommand):
+class AddLinkCommand(UndoCommand):
     def __init__(self, scheme, link, parent=None):
-        # type: (Scheme, SchemeLink, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeLink, Optional[UndoCommand]) -> None
         super().__init__("Add link", parent)
         self.scheme = scheme
         self.link = link
@@ -69,9 +130,9 @@ class AddLinkCommand(QUndoCommand):
         self.scheme.remove_link(self.link)
 
 
-class RemoveLinkCommand(QUndoCommand):
+class RemoveLinkCommand(UndoCommand):
     def __init__(self, scheme, link, parent=None):
-        # type: (Scheme, SchemeLink, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeLink, Optional[UndoCommand]) -> None
         super().__init__("Remove link", parent)
         self.scheme = scheme
         self.link = link
@@ -83,14 +144,14 @@ class RemoveLinkCommand(QUndoCommand):
         self.scheme.add_link(self.link)
 
 
-class InsertNodeCommand(QUndoCommand):
+class InsertNodeCommand(UndoCommand):
     def __init__(
             self,
             scheme,     # type: Scheme
             new_node,   # type: SchemeNode
             old_link,   # type: SchemeLink
             new_links,  # type: Tuple[SchemeLink, SchemeLink]
-            parent=None # type: Optional[QUndoCommand]
+            parent=None # type: Optional[UndoCommand]
     ):  # type: (...) -> None
         super().__init__("Insert widget into link", parent)
 
@@ -100,9 +161,9 @@ class InsertNodeCommand(QUndoCommand):
             AddLinkCommand(scheme, link, parent=self)
 
 
-class AddAnnotationCommand(QUndoCommand):
+class AddAnnotationCommand(UndoCommand):
     def __init__(self, scheme, annotation, parent=None):
-        # type: (Scheme, BaseSchemeAnnotation, Optional[QUndoCommand]) -> None
+        # type: (Scheme, BaseSchemeAnnotation, Optional[UndoCommand]) -> None
         super().__init__("Add annotation", parent)
         self.scheme = scheme
         self.annotation = annotation
@@ -114,9 +175,9 @@ class AddAnnotationCommand(QUndoCommand):
         self.scheme.remove_annotation(self.annotation)
 
 
-class RemoveAnnotationCommand(QUndoCommand):
+class RemoveAnnotationCommand(UndoCommand):
     def __init__(self, scheme, annotation, parent=None):
-        # type: (Scheme, BaseSchemeAnnotation, Optional[QUndoCommand]) -> None
+        # type: (Scheme, BaseSchemeAnnotation, Optional[UndoCommand]) -> None
         super().__init__("Remove annotation", parent)
         self.scheme = scheme
         self.annotation = annotation
@@ -128,9 +189,9 @@ class RemoveAnnotationCommand(QUndoCommand):
         self.scheme.add_annotation(self.annotation)
 
 
-class MoveNodeCommand(QUndoCommand):
+class MoveNodeCommand(UndoCommand):
     def __init__(self, scheme, node, old, new, parent=None):
-        # type: (Scheme, SchemeNode, Pos, Pos, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeNode, Pos, Pos, Optional[UndoCommand]) -> None
         super().__init__("Move", parent)
         self.scheme = scheme
         self.node = node
@@ -144,9 +205,9 @@ class MoveNodeCommand(QUndoCommand):
         self.node.position = self.old
 
 
-class ResizeCommand(QUndoCommand):
+class ResizeCommand(UndoCommand):
     def __init__(self, scheme, item, new_geom, parent=None):
-        # type: (Scheme, SchemeTextAnnotation, Rect, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeTextAnnotation, Rect, Optional[UndoCommand]) -> None
         super().__init__("Resize", parent)
         self.scheme = scheme
         self.item = item
@@ -160,9 +221,9 @@ class ResizeCommand(QUndoCommand):
         self.item.rect = self.old_geom
 
 
-class ArrowChangeCommand(QUndoCommand):
+class ArrowChangeCommand(UndoCommand):
     def __init__(self, scheme, item, new_line, parent=None):
-        # type: (Scheme, SchemeArrowAnnotation, Line, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeArrowAnnotation, Line, Optional[UndoCommand]) -> None
         super().__init__("Move arrow", parent)
         self.scheme = scheme
         self.item = item
@@ -176,14 +237,14 @@ class ArrowChangeCommand(QUndoCommand):
         self.item.set_line(*self.old_line)
 
 
-class AnnotationGeometryChange(QUndoCommand):
+class AnnotationGeometryChange(UndoCommand):
     def __init__(
             self,
             scheme,  # type: Scheme
             annotation,  # type: BaseSchemeAnnotation
             old,  # type: Any
             new,  # type: Any
-            parent=None  # type: Optional[QUndoCommand]
+            parent=None  # type: Optional[UndoCommand]
     ):  # type: (...) -> None
         super().__init__("Change Annotation Geometry", parent)
         self.scheme = scheme
@@ -198,9 +259,9 @@ class AnnotationGeometryChange(QUndoCommand):
         self.annotation.geometry = self.old  # type: ignore
 
 
-class RenameNodeCommand(QUndoCommand):
+class RenameNodeCommand(UndoCommand):
     def __init__(self, scheme, node, old_name, new_name, parent=None):
-        # type: (Scheme, SchemeNode, str, str, Optional[QUndoCommand]) -> None
+        # type: (Scheme, SchemeNode, str, str, Optional[UndoCommand]) -> None
         super().__init__("Rename", parent)
         self.scheme = scheme
         self.node = node
@@ -214,7 +275,7 @@ class RenameNodeCommand(QUndoCommand):
         self.node.set_title(self.old_name)
 
 
-class TextChangeCommand(QUndoCommand):
+class TextChangeCommand(UndoCommand):
     def __init__(
             self,
             scheme,       # type: Scheme
@@ -223,7 +284,7 @@ class TextChangeCommand(QUndoCommand):
             old_content_type,  # type: str
             new_content,  # type: str
             new_content_type,  # type: str
-            parent=None   # type: Optional[QUndoCommand]
+            parent=None   # type: Optional[UndoCommand]
     ):  # type: (...) -> None
         super().__init__("Change text", parent)
         self.scheme = scheme
@@ -240,14 +301,14 @@ class TextChangeCommand(QUndoCommand):
         self.annotation.set_content(self.old_content, self.old_content_type)
 
 
-class SetAttrCommand(QUndoCommand):
+class SetAttrCommand(UndoCommand):
     def __init__(
             self,
             obj,         # type: Any
             attrname,    # type: str
             newvalue,    # type: Any
             name=None,   # type: Optional[str]
-            parent=None  # type: Optional[QUndoCommand]
+            parent=None  # type: Optional[UndoCommand]
     ):  # type: (...) -> None
         if name is None:
             name = "Set %r" % attrname
@@ -264,7 +325,7 @@ class SetAttrCommand(QUndoCommand):
         setattr(self.obj, self.attrname, self.oldvalue)
 
 
-class SimpleUndoCommand(QUndoCommand):
+class SimpleUndoCommand(UndoCommand):
     """
     Simple undo/redo command specified by callable function pair.
     Parameters
@@ -274,8 +335,8 @@ class SimpleUndoCommand(QUndoCommand):
     undo : Callable[[], None]
         A function expressing a undo action.
     text : str
-        The command's text (see `QUndoCommand.setText`)
-    parent : Optional[QUndoCommand]
+        The command's text (see `UndoCommand.setText`)
+    parent : Optional[UndoCommand]
     """
 
     def __init__(
@@ -283,7 +344,7 @@ class SimpleUndoCommand(QUndoCommand):
             redo,  # type: Callable[[], None]
             undo,  # type: Callable[[], None]
             text,  # type: str
-            parent=None  # type: Optional[QUndoCommand]
+            parent=None  # type: Optional[UndoCommand]
     ):  # type: (...) -> None
         super().__init__(text, parent)
         self._redo = redo

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -31,6 +31,7 @@ from AnyQt.QtCore import (
 )
 from AnyQt.QtCore import pyqtSignal as Signal
 
+from orangecanvas.document.commands import UndoCommand
 from .usagestatistics import UsageStatistics
 from ..registry.description import WidgetDescription, OutputSignal, InputSignal
 from ..registry.qt import QtWidgetRegistry
@@ -281,8 +282,8 @@ class NewLinkAction(UserInteraction):
         self.tmp_anchor_point = None     # type: Optional[items.AnchorPoint]
         # An `AnchorPoint` following the mouse cursor
         self.cursor_anchor_point = None  # type: Optional[items.AnchorPoint]
-        # An QUndoCommand
-        self.macro = None  # type: Optional[QUndoCommand]
+        # An UndoCommand
+        self.macro = None  # type: Optional[UndoCommand]
 
         self.cancelOnEsc = True
 
@@ -460,7 +461,7 @@ class NewLinkAction(UserInteraction):
             node = None  # type: Optional[Node]
             stack = self.document.undoStack()
 
-            self.macro = QUndoCommand(self.tr("Add link"))
+            self.macro = UndoCommand(self.tr("Add link"))
 
             if item:
                 # If the release was over a node item then connect them

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -36,6 +36,7 @@ from AnyQt.QtCore import (
     QMimeData, Slot)
 from AnyQt.QtCore import pyqtProperty as Property, pyqtSignal as Signal
 
+from orangecanvas.document.commands import UndoCommand
 from ..registry import WidgetDescription, WidgetRegistry
 from .suggestions import Suggestions
 from .usagestatistics import UsageStatistics
@@ -2007,7 +2008,7 @@ class SchemeEditWidget(QWidget):
         if commandname is None:
             commandname = self.tr("Paste")
         # create nodes, links
-        command = QUndoCommand(commandname)
+        command = UndoCommand(commandname)
         macrocommands = []
         for nodedup in nodedups:
             macrocommands.append(

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -655,6 +655,9 @@ class SchemeEditWidget(QWidget):
             ignore=ignore
         ))
 
+    def restoreProperties(self, dict_diff):
+        dictdiffer.patch(dict_diff, node_properties(self.__scheme), in_place=True)
+
     def cleanNodes(self):
         return list(self.__cleanProperties.keys())
 

--- a/orangecanvas/scheme/annotations.py
+++ b/orangecanvas/scheme/annotations.py
@@ -108,6 +108,16 @@ class SchemeArrowAnnotation(BaseSchemeAnnotation):
 
     color = Property(str, fget=color, fset=set_color)  # type: ignore
 
+    def __getstate__(self):
+        return self.__start_pos, \
+               self.__end_pos, \
+               self.__color, \
+               self.__anchor, \
+               self.parent()
+
+    def __setstate__(self, state):
+        self.__init__(*state)
+
 
 class SchemeTextAnnotation(BaseSchemeAnnotation):
     """
@@ -253,3 +263,14 @@ class SchemeTextAnnotation(BaseSchemeAnnotation):
         return dict(self.__font)
 
     font = Property(str, fget=font, fset=set_font)  # type: ignore
+
+    def __getstate__(self):
+        return self.__rect, \
+               self.__content, \
+               self.__content_type, \
+               self.__font, \
+               self.__anchor, \
+               self.parent()
+
+    def __setstate__(self, state):
+        self.__init__(*state)

--- a/orangecanvas/scheme/link.py
+++ b/orangecanvas/scheme/link.py
@@ -431,3 +431,20 @@ class SchemeLink(QObject):
             self.source_node.title, self.source_channel.name,
             self.sink_node.title, self.sink_channel.name
         )
+
+    def __getstate__(self):
+        return self.source_node, \
+               self.source_channel.name, \
+               self.sink_node, \
+               self.sink_channel.name, \
+               self.__enabled, \
+               self.properties, \
+               self.parent()
+
+    def __setstate__(self, state):
+        mutable_state = list(state)
+        # correct source channel
+        mutable_state[1] = state[0].output_channel(state[1])
+        # correct sink channel
+        mutable_state[3] = state[2].input_channel(state[3])
+        self.__init__(*mutable_state)

--- a/orangecanvas/scheme/node.py
+++ b/orangecanvas/scheme/node.py
@@ -368,3 +368,13 @@ class SchemeNode(QObject):
 
     def __repr__(self):
         return str(self)
+
+    def __getstate__(self):
+        return self.description, \
+               self.__title, \
+               self.__position, \
+               self.properties, \
+               self.parent()
+
+    def __setstate__(self, state):
+        self.__init__(*state)

--- a/orangecanvas/utils/pickle.py
+++ b/orangecanvas/utils/pickle.py
@@ -1,0 +1,80 @@
+import glob
+import os
+import pickle
+
+from orangecanvas import config
+from ..scheme import Scheme, SchemeNode, SchemeLink
+
+
+class Pickler(pickle.Pickler):
+    def __init__(self, file, document):
+        super().__init__(file)
+        self.document = document
+
+    def persistent_id(self, obj):
+        if isinstance(obj, Scheme):
+            return 'scheme'
+        elif isinstance(obj, SchemeNode) and obj in self.document.cleanNodes():
+            return "SchemeNode_" + str(self.document.cleanNodes().index(obj))
+        elif isinstance(obj, SchemeLink) and obj in self.document.cleanLinks():
+            return "SchemeLink_" + str(self.document.cleanLinks().index(obj))
+        else:
+            return None
+
+
+class Unpickler(pickle.Unpickler):
+    def __init__(self, file, scheme):
+        super().__init__(file)
+        self.scheme = scheme
+
+    def persistent_load(self, pid: str):
+        if pid == 'scheme':
+            return self.scheme
+        elif pid.startswith('SchemeNode_'):
+            node_index = int(pid.split('_')[1])
+            return self.scheme.nodes[node_index]
+        elif pid.startswith('SchemeLink_'):
+            link_index = int(pid.split('_')[1])
+            return self.scheme.links[link_index]
+        else:
+            raise pickle.UnpicklingError("Unsupported persistent object")
+
+
+def scratch_swp_base_name():
+    filename = 'scratch.swp.p'
+    dirname = os.path.join(config.data_dir(), 'scratch-crashes')
+    os.makedirs(dirname, exist_ok=True)
+    swpname = os.path.join(dirname, filename)
+    return swpname
+
+
+canvas_scratch_name_memo = {}
+
+
+def swp_name(canvas):
+    document = canvas.current_document()
+    if document.path():
+        filename = os.path.basename(document.path())
+        dirname = os.path.dirname(document.path())
+        return os.path.join(dirname, '.' + filename + ".swp.p")
+    # else it's a scratch workflow
+
+    global canvas_scratch_name_memo
+    if canvas in canvas_scratch_name_memo:
+        return canvas_scratch_name_memo[canvas]
+
+    swpname = scratch_swp_base_name()
+
+    i = 0
+    while os.path.exists(swpname + '.' + str(i)):
+        i += 1
+    swpname += '.' + str(i)
+
+    canvas_scratch_name_memo[canvas] = swpname
+
+    return swpname
+
+
+def glob_scratch_swps():
+    swpname = scratch_swp_base_name()
+    return glob.glob(swpname + ".*")

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ INSTALL_REQUIRES = (
     "requests",
     "cachecontrol[filecache]",
     "pip>=18.0",
+    "dictdiffer"
 )
 
 


### PR DESCRIPTION
![Screen-Recording-2020-02-03-at-16 05](https://user-images.githubusercontent.com/24586651/73669651-b940d680-469f-11ea-8f21-6694beedd2e3.gif)
(note: crashed changes for scratch workflows are loaded on startup like this with https://github.com/biolab/orange3/pull/4392)

As outlined in #44, this PR saves the undo stack since its last clean state, and the diff of 'clean node' properties since last clean state, any time a command is pushed to the undo stack.

This is saved to `./.workflow.ows.swp.p` if it's a saved workflow, or `configdir/scratch-crashes/scratch.swp.p.0` if it's a scratch workflow, where 0 is incremented in the case of several crashed scratch workflows.

I've not yet extensively tested the pickling and restoring of node properties; an issue would arise if a property is unpicklable. There are ways to combat this, e.g., ignoring the property in `uncleanProperties()`, as are contexts.

**TODO**
- [x] Save swp for scratch workflow
- [x] Load swp with QDialog
- [x] Delete swp on graceful close
- [x] Tests
- [x] Serialize annotations
- [x] Serialize arrows