### PR TITLE
Fixes for testing with PyQt 5.14

### DIFF
--- a/orangecanvas/application/tests/test_mainwindow.py
+++ b/orangecanvas/application/tests/test_mainwindow.py
@@ -13,18 +13,30 @@ from ...registry import tests as registry_tests
 
 
 class MainWindow(CanvasMainWindow):
-    pass
+    _instances = []
+
+    def create_new_window(self):  # type: () -> CanvasMainWindow
+        inst = super().create_new_window()
+        MainWindow._instances.append(inst)
+        return inst
 
 
 class TestMainWindowBase(QAppTestCase):
     def setUp(self):
+        super().setUp()
         self.w = MainWindow()
         self.registry = registry_tests.small_testing_registry()
         self.w.set_widget_registry(self.registry)
 
     def tearDown(self):
+        self.w.deleteLater()
+        for w in MainWindow._instances:
+            w.deleteLater()
+        MainWindow._instances.clear()
         del self.w
         del self.registry
+        self.qWait(1)
+        super().tearDown()
 
 
 class TestMainWindow(TestMainWindowBase):
@@ -39,6 +51,7 @@ class TestMainWindow(TestMainWindowBase):
         new.show()
 
         w.set_scheme_margins_enabled(True)
+        new.deleteLater()
 
     def test_new_window(self):
         w = self.w
@@ -99,6 +112,7 @@ class TestMainWindowLoad(TestMainWindowBase):
     def tearDown(self):
         self.file.close()
         os.remove(self.filename)
+        super().tearDown()
 
     def test_open_example_scheme(self):
         self.file.write(TEST_OWS)

--- a/orangecanvas/gui/test.py
+++ b/orangecanvas/gui/test.py
@@ -10,6 +10,7 @@ from AnyQt.QtWidgets import QApplication, QWidget
 from AnyQt.QtCore import QCoreApplication, QTimer, QStandardPaths, QPoint, Qt
 from AnyQt.QtGui import QMouseEvent
 from AnyQt.QtTest import QTest
+from AnyQt.QtCore import PYQT_VERSION
 
 DEFAULT_TIMEOUT = 50
 
@@ -45,7 +46,10 @@ class QCoreAppTestCase(unittest.TestCase):
         gc.collect()
         cls.app.setApplicationName(cls.__appname)
         cls.app.setOrganizationDomain(cls.__appdomain)
-        cls.app = None
+        cls.app.sendPostedEvents(None, 0)
+        # Keep app instance alive between tests with PyQt5 5.14.0 and later
+        if PYQT_VERSION <= 0x050e00:
+            cls.app = None
         super(QCoreAppTestCase, cls).tearDownClass()
         QStandardPaths.setTestModeEnabled(False)
 

--- a/orangecanvas/gui/tests/test_stackedwidget.py
+++ b/orangecanvas/gui/tests/test_stackedwidget.py
@@ -16,7 +16,6 @@ class TestStackedWidget(test.QAppTestCase):
         window.setLayout(layout)
 
         stack = stackedwidget.AnimatedStackedWidget(animationEnabled=False)
-        stack.transitionFinished.connect(self.app.exit)
 
         layout.addStretch(2)
         layout.addWidget(stack)
@@ -66,14 +65,13 @@ class TestStackedWidget(test.QAppTestCase):
         self.assertSequenceEqual([widget1, widget2, widget3],
                                  widgets())
 
-        stack.transitionFinished.disconnect(self.app.exit)
-
         def toogle():
             idx = stack.currentIndex()
             stack.setCurrentIndex((idx + 1) % stack.count())
 
-        timer = QTimer(stack, interval=1000)
+        timer = QTimer(stack, interval=100)
         timer.timeout.connect(toogle)
         timer.start()
-        self.qWait()
+        self.qWait(200)
         timer.stop()
+        window.deleteLater()

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -75,6 +75,8 @@ class WidgetManager(QObject):
     #: A QWidget was removed, hidden and will be deleted when appropriate.
     widget_for_node_removed = Signal(SchemeNode, QWidget)
 
+    __init_queue = None  # type: Deque[SchemeNode]
+
     class CreationPolicy(enum.Enum):
         """
         Widget Creation Policy.
@@ -102,7 +104,7 @@ class WidgetManager(QObject):
         self.__item_for_node = {}  # type: Dict[SchemeNode, Item]
         self.__item_for_widget = {}  # type: Dict[QWidget, Item]
 
-        self.__init_queue = deque()  # type: Deque[SchemeNode]
+        self.__init_queue = deque()
 
         self.__init_timer = QTimer(self, singleShot=True)
         self.__init_timer.timeout.connect(self.__process_init_queue)

--- a/orangecanvas/utils/tests/test_resources.py
+++ b/orangecanvas/utils/tests/test_resources.py
@@ -8,11 +8,9 @@ from orangecanvas.resources import icon_loader
 class TestIconLoader(unittest.TestCase):
     def setUp(self):
         from AnyQt.QtWidgets import QApplication
-        self.app = QApplication([])
-
-    def tearDown(self):
-        self.app.exit()
-        del self.app
+        self.app = QApplication.instance()
+        if self.app is None:
+            self.app = QApplication([])
 
     def test_loader(self):
         loader = icon_loader()


### PR DESCRIPTION
#### Issue

Tests fail randomly with PyQt5 5.14.*

Ref: https://github.com/biolab/orange-canvas-core/pull/79#issuecomment-583663808

#### Changes

* Preserve QApplication between tests when running tests with PyQt5 >= 5.14
* Fix some resulting errors in tests due to changed test setup/teardown
 
