### PR TITLE
Try to fix Qt plugins search path

### DIFF
--- a/orangecanvas/application/application.py
+++ b/orangecanvas/application/application.py
@@ -2,11 +2,86 @@
 Orange Canvas Application
 
 """
+import os
 import argparse
+from typing import Optional
 
+import AnyQt
 from AnyQt.QtWidgets import QApplication
+from AnyQt.QtCore import (
+    Qt, QUrl, QEvent, QSettings, QLibraryInfo, pyqtSignal as Signal
+)
 
-from AnyQt.QtCore import Qt, QUrl, QEvent, QSettings, pyqtSignal as Signal
+
+def fix_qt_plugins_path():
+    """
+    Attempt to fix qt plugins path if it is invalid.
+
+    https://www.riverbankcomputing.com/pipermail/pyqt/2018-November/041089.html
+    """
+    # PyQt5 loads a runtime generated qt.conf file into qt's resource system
+    # but does not correctly (INI) encode non-latin1 characters in paths
+    # (https://www.riverbankcomputing.com/pipermail/pyqt/2018-November/041089.html)
+    # Need to be careful not to mess the plugins path when not installed as
+    # a (delocated) wheel.
+    s = QSettings(":qt/etc/qt.conf", QSettings.IniFormat)
+    path = s.value("Paths/Prefix", type=str)
+    # does the ':qt/etc/qt.conf' exist and has prefix path that does not exist
+    if path and os.path.exists(path):
+        return
+    # Use QLibraryInfo.location to resolve the plugins dir
+    pluginspath = QLibraryInfo.location(QLibraryInfo.PluginsPath)
+
+    # Check effective library paths. Someone might already set the search
+    # paths (including via QT_PLUGIN_PATH). QApplication.libraryPaths() returns
+    # existing paths only.
+    paths = QApplication.libraryPaths()
+    if paths:
+        return
+
+    if AnyQt.USED_API == "pyqt5":
+        import PyQt5.QtCore as qc
+    elif AnyQt.USED_API == "pyside2":
+        import PySide2.QtCore as qc
+    else:
+        return
+
+    def normpath(path):
+        return os.path.normcase(os.path.normpath(path))
+
+    # guess the appropriate path relative to the installation dir based on the
+    # PyQt5 installation dir and the 'recorded' plugins path. I.e. match the
+    # 'PyQt5' directory name in the recorded path and replace the 'invalid'
+    # prefix with the real PyQt5 install dir.
+    def maybe_match_prefix(prefix: str, path: str) -> Optional[str]:
+        """
+        >>> maybe_match_prefix("aa/bb/cc", "/a/b/cc/a/b")
+        "aa/bb/cc/a/b"
+        >>> maybe_match_prefix("aa/bb/dd", "/a/b/cc/a/b")
+        None
+        """
+        prefix = normpath(prefix)
+        path = normpath(path)
+        basename = os.path.basename(prefix)
+        path_components = path.split(os.sep)
+        # find the (rightmost) basename in the prefix_components
+        idx = None
+        try:
+            start = 0
+            while True:
+                idx = path_components.index(basename, start)
+                start = idx + 1
+        except ValueError:
+            pass
+        if idx is None:
+            return
+        return os.path.join(prefix, *path_components[idx + 1:])
+
+    newpath = maybe_match_prefix(
+        os.path.dirname(qc.__file__), pluginspath
+    )
+    if newpath is not None and os.path.exists(newpath):
+        QApplication.addLibraryPath(newpath)
 
 
 class CanvasApplication(QApplication):
@@ -15,6 +90,7 @@ class CanvasApplication(QApplication):
     __args = None
 
     def __init__(self, argv):
+        fix_qt_plugins_path()
         if hasattr(Qt, "AA_EnableHighDpiScaling"):
             # Turn on HighDPI support when available
             QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)


### PR DESCRIPTION
### Issue

Ref https://github.com/biolab/orange3/issues/4488

When PyQt5 is installed from wheel file into a path with non-latin1
characters, the platform plugins cannot be loaded and the application
cannot start.

### Changes

Try to detect non valid plugins path and attempt to set explicit search path with `QCoreApplication.addLibraryPath`