### PR TITLE
Crash recovery bugfix, scratch workflow config option

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1631,7 +1631,8 @@ class CanvasMainWindow(QMainWindow):
                 return
         else:
             swpnames = glob_scratch_swps()
-            if not swpnames:
+            if not swpnames or \
+                    all([s in canvas_scratch_name_memo.values() for s in swpnames]):
                 return
 
         self.ask_load_swp()

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1579,7 +1579,8 @@ class CanvasMainWindow(QMainWindow):
             return
 
         swpname = swp_name(self)
-        self.save_swp_to(swpname)
+        if swpname is not None:
+            self.save_swp_to(swpname)
 
     def save_swp_to(self, filename):
         """
@@ -1630,6 +1631,8 @@ class CanvasMainWindow(QMainWindow):
             if not os.path.exists(swpname):
                 return
         else:
+            if not QSettings().value('startup/load-crashed-workflows', True, type=bool):
+                return
             swpnames = glob_scratch_swps()
             if not swpnames or \
                     all([s in canvas_scratch_name_memo.values() for s in swpnames]):

--- a/orangecanvas/application/settings.py
+++ b/orangecanvas/application/settings.py
@@ -329,13 +329,18 @@ class UserSettingsDialog(QMainWindow):
                               objectName="show-splash-screen")
 
         cb_welcome = QCheckBox(self.tr("Show welcome screen"), self,
-                                objectName="show-welcome-screen")
+                               objectName="show-welcome-screen")
+
+        cb_crash = QCheckBox(self.tr("Load crashed scratch workflows"), self,
+                             objectName="load-crashed-workflows")
 
         self.bind(cb_splash, "checked", "startup/show-splash-screen")
         self.bind(cb_welcome, "checked", "startup/show-welcome-screen")
+        self.bind(cb_crash, "checked", "startup/load-crashed-workflows")
 
         startup.layout().addWidget(cb_splash)
         startup.layout().addWidget(cb_welcome)
+        startup.layout().addWidget(cb_crash)
 
         form.addRow(self.tr("On startup"), startup)
 

--- a/orangecanvas/application/tests/test_mainwindow.py
+++ b/orangecanvas/application/tests/test_mainwindow.py
@@ -181,6 +181,14 @@ class TestMainWindowLoad(TestMainWindowBase):
         w2.clear_swp()
         del w2
 
+    def test_dont_load_swp_on_new_window(self):
+        w = self.w
+        desc = self.registry.widgets()[0]
+        w.current_document().createNewNode(desc)
+
+        with patch.object(CanvasMainWindow, 'ask_load_swp', self.fail):
+            w.new_workflow_window()
+
     def test_open_ows_req(self):
         w = self.w
         with temp_named_file(TEST_OWS_REQ.decode()) as f:

--- a/orangecanvas/config.py
+++ b/orangecanvas/config.py
@@ -351,10 +351,13 @@ rc = {}  # type: ignore
 
 spec = \
     [("startup/show-splash-screen", bool, True,
-      "Show splash screen at startup"),
+      "Show splash screen on startup"),
 
      ("startup/show-welcome-screen", bool, True,
-      "Show Welcome screen at startup"),
+      "Show Welcome screen on startup"),
+
+     ("startup/load-crashed-workflows", bool, True,
+      "Load crashed scratch workflows on startup"),
 
      ("stylesheet", str, "orange",
       "QSS stylesheet to use"),

--- a/orangecanvas/utils/pickle.py
+++ b/orangecanvas/utils/pickle.py
@@ -2,6 +2,8 @@ import glob
 import os
 import pickle
 
+from PyQt5.QtCore import QSettings
+
 from orangecanvas import config
 from ..scheme import Scheme, SchemeNode, SchemeLink
 
@@ -58,6 +60,9 @@ def swp_name(canvas):
         dirname = os.path.dirname(document.path())
         return os.path.join(dirname, '.' + filename + ".swp.p")
     # else it's a scratch workflow
+
+    if not QSettings().value('startup/load-crashed-workflows', True, type=bool):
+        return None
 
     global canvas_scratch_name_memo
     if canvas in canvas_scratch_name_memo:


### PR DESCRIPTION
#97 

- canvasmain: Bugfix for loading swp of open workflow
- config: Add option for not loading/saving scratch workflows