### PR TITLE
add-on dialog: fix drag-and-drop support for already installed add-ons

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -327,7 +327,7 @@ class PluginsModel(QStandardItemModel):
             ins, dist = item.installable, item.local
             name = dist.project_name
             summary = get_dist_meta(dist).get("Summary", "")
-            version = ins.version if ins is not None else dist.version
+            version = dist.version
             item_is_core = item.required
         else:
             installed = False


### PR DESCRIPTION
Archives containing already installed add-ons did not work. Now, whatever is dropped is installed. These changes allow installing arbitrary versions (old, or perhaps unreleased) through drag-and-drop onto the dialog.

Another change: the installed versions are now displayed even if installed version is greater than pypi version.