### PR TITLE
[FIX] signalmanager: Fix compress_signals

### DIFF
--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -1054,7 +1054,9 @@ def compress_signals(signals):
         return any(sig.value is None for sig in signals)
 
     for (link, id), signals_grouped in groups:
-        if len(signals_grouped) > 1 and has_none(signals_grouped[1:]):
+        if has_none(signals_grouped[:1]):
+            signals.append(signals_grouped[0])
+        elif len(signals_grouped) > 1 and has_none(signals_grouped[1:]):
             signals.append(signals_grouped[0])
             signals.append(Signal(link, None, id))
         else:

--- a/orangecanvas/scheme/tests/test_signalmanager.py
+++ b/orangecanvas/scheme/tests/test_signalmanager.py
@@ -209,6 +209,14 @@ class TestSignalManager(unittest.TestCase):
             compress_signals(signals_in),
             signals_in[1:],
         )
+        signals_in = [
+            Signal(link, None, 1),
+            Signal(link, None, 1),
+        ]
+        self.assertSequenceEqual(
+            compress_signals(signals_in),
+            signals_in[1:],
+        )
 
 
 class TestSCC(unittest.TestCase):


### PR DESCRIPTION
#### Issue

compress_signals should compress `None` signals when `None` is last in sequence.

#### Changes

Compress 'None' signals when 'None' is last in sequence
