### PR TITLE
Conda installer: add --satisfied-skip-solve

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1486,12 +1486,14 @@ class CondaInstaller:
     def install(self, pkg, raise_on_fail=False):
         version = "={}".format(pkg.version) if pkg.version is not None else ""
         cmd = [self.conda, "install", "--yes", "--quiet",
+               "--satisfied-skip-solve",
                self._normalize(pkg.name) + version]
         run_command(cmd, raise_on_fail=raise_on_fail)
 
     def upgrade(self, pkg, raise_on_fail=False):
         version = "={}".format(pkg.version) if pkg.version is not None else ""
         cmd = [self.conda, "install", "--yes", "--quiet",
+               "--satisfied-skip-solve",
                self._normalize(pkg.name) + version]
         run_command(cmd, raise_on_fail=raise_on_fail)
 


### PR DESCRIPTION
Fixes https://github.com/biolab/orange3/issues/4844

With @markotoplak, we discussed that conda and pip installer should have similar behavior. Pip's behavior while installing packages is to upgrade/downgrade packages only if needed while conda upgrade them while installing new packages. Conda's behavior can cause problems in cases similar to the one that just happened whit scikit-learn. The package gets a new release which is incompatible with Orange. Orange will still work since it has an older version of a package in the installer, but when someone installs the add-on packages are upgraded and Orange stops working.

This flag should solve those problems. But do we want that? 
This flag was added in the conda version 4.6.0, we are currently building installers with Miniconda 4.7.12, so it should be ok. Is there any other problem?