### PR TITLE
Scheme: explicitly set pickle protocol to v4

### DIFF
--- a/orangecanvas/scheme/readwrite.py
+++ b/orangecanvas/scheme/readwrite.py
@@ -37,6 +37,9 @@ from ..registry import WidgetDescription, InputSignal, OutputSignal
 
 log = logging.getLogger(__name__)
 
+# protocol v4 is supported since Python 3.4, protocol v5 since Python 3.8
+PICKLE_PROTOCOL = 4
+
 
 class UnknownWidgetDefinition(Exception):
     pass
@@ -715,14 +718,16 @@ def dumps(obj, format="literal", prettyprint=False, pickle_fallback=False):
                         exc_info=True)
 
     elif format == "pickle":
-        return base64.encodebytes(pickle.dumps(obj)).decode('ascii'), "pickle"
+        return base64.encodebytes(pickle.dumps(obj, protocol=PICKLE_PROTOCOL)). \
+                   decode('ascii'), "pickle"
 
     else:
         raise ValueError("Unsupported format %r" % format)
 
     if pickle_fallback:
         log.warning("Using pickle fallback")
-        return base64.encodebytes(pickle.dumps(obj)).decode('ascii'), "pickle"
+        return base64.encodebytes(pickle.dumps(obj, protocol=PICKLE_PROTOCOL)). \
+                   decode('ascii'), "pickle"
     else:
         raise Exception("Something strange happened.")
 


### PR DESCRIPTION
Setting this to avoid potential future problems. Before, pickle protocol 3 was used for Python <= 3.7 and 4 for Python 3.8. Protocol v4 is compatible with Python>=3.4, which is also the minimum supported python for orange-canvas-core.