### PR TITLE
[FIX] Window Group Undo/Redo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ install:
 
 script:
   - pip list --format=freeze
-  - xvfb-run -a -s "$XVFBARGS" python -m unittest discover -v -b .
+  - catchsegv xvfb-run -a -s "$XVFBARGS" python -m unittest discover -v -b .

--- a/orangecanvas/document/commands.py
+++ b/orangecanvas/document/commands.py
@@ -3,7 +3,7 @@ Undo/Redo Commands
 
 """
 import typing
-from typing import Callable, Optional, Tuple, Any
+from typing import Callable, Optional, Tuple, List, Any
 
 from AnyQt.QtWidgets import QUndoCommand
 
@@ -333,6 +333,30 @@ class SetAttrCommand(UndoCommand):
 
     def undo(self):
         setattr(self.obj, self.attrname, self.oldvalue)
+
+
+class SetWindowGroupPresets(UndoCommand):
+    def __init__(
+            self,
+            scheme: 'Scheme',
+            presets: List['Scheme.WindowGroup'],
+            parent: Optional[UndoCommand] = None,
+            **kwargs
+    ) -> None:
+        text = kwargs.pop("text", "Set Window Presets")
+        super().__init__(text, parent, **kwargs)
+        self.scheme = scheme
+        self.presets = presets
+        self.__undo_presets = None
+
+    def redo(self):
+        presets = self.scheme.window_group_presets()
+        self.scheme.set_window_group_presets(self.presets)
+        self.__undo_presets = presets
+
+    def undo(self):
+        self.scheme.set_window_group_presets(self.__undo_presets)
+        self.__undo_presets = None
 
 
 class SimpleUndoCommand(UndoCommand):

--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -21,7 +21,6 @@ from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 from .node import SchemeNode
 from .link import SchemeLink, compatible_channels, _classify_connection
 from .annotations import BaseSchemeAnnotation
-
 from ..utils import check_arg, findf
 
 from .errors import (
@@ -819,7 +818,7 @@ class Scheme(QObject):
     window_group_presets_changed = Signal()
 
     def window_group_presets(self):
-        # type: () -> List[Scheme.WindowGroup]
+        # type: () -> List[WindowGroup]
         """
         Return a collection of preset window groups and their encoded states.
 
@@ -828,7 +827,7 @@ class Scheme(QObject):
         return self.property("_presets") or []
 
     def set_window_group_presets(self, groups):
-        # type: (List[Scheme.WindowGroup]) -> None
+        # type: (List[WindowGroup]) -> None
         self.setProperty("_presets", groups)
         self.window_group_presets_changed.emit()
 

--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -816,6 +816,8 @@ class Scheme(QObject):
         def __init__(self, name="", default=False, state=[]):
             super().__init__(name=name, default=default, state=state)
 
+    window_group_presets_changed = Signal()
+
     def window_group_presets(self):
         # type: () -> List[Scheme.WindowGroup]
         """
@@ -828,6 +830,7 @@ class Scheme(QObject):
     def set_window_group_presets(self, groups):
         # type: (List[Scheme.WindowGroup]) -> None
         self.setProperty("_presets", groups)
+        self.window_group_presets_changed.emit()
 
 
 from . import readwrite


### PR DESCRIPTION
#### Issue

After saving a window group (View -> Window Groups -> Save Window Group) any modification to the workflow logs an error:
```
ERROR:orangecanvas.application.canvasmain:Could not write swp file '/Users/aleserjavec/Library/Application Support/Orange/3.27.0.dev/scratch-crashes/scratch.swp.p.0'.
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/application/canvasmain.py", line 1605, in save_swp_to
    Pickler(f, document).dump(diff)
AttributeError: Can't pickle local object 'SchemeEditWidget.__saveWindowGroup.<locals>.store_group.<locals>.redo'
```

#### Changes

* Add notifier signal for `Scheme.window_group_presets`
* Remove use of SimpleUndoCommand with local closure thunks. Instead implement a dedicated command.
* Add simple test