### PR TITLE
[FIX] Undo/redo does not preserve order

### DIFF
--- a/docs/source/orangecanvas/scheme.events.rst
+++ b/docs/source/orangecanvas/scheme.events.rst
@@ -52,18 +52,21 @@ Workflow Events (``events``)
    :show-inheritance:
 
    .. automethod:: node() -> SchemeNode
+   .. automethod:: pos() -> int
 
 
 .. autoclass:: orangecanvas.scheme.events.LinkEvent
    :show-inheritance:
 
    .. automethod:: link() -> SchemeLink
+   .. automethod:: pos() -> int
 
 
 .. autoclass:: orangecanvas.scheme.events.AnnotationEvent
    :show-inheritance:
 
    .. automethod:: annotation() -> BaseSchemeAnnotation
+   .. automethod:: pos() -> int
 
 
 .. autoclass:: orangecanvas.scheme.events.WorkflowEnvChanged
@@ -72,6 +75,3 @@ Workflow Events (``events``)
    .. automethod:: name() -> str
    .. automethod:: oldValue() -> Any
    .. automethod:: newValue() -> Any
-
-
-

--- a/orangecanvas/document/commands.py
+++ b/orangecanvas/document/commands.py
@@ -98,7 +98,7 @@ class RemoveNodeCommand(UndoCommand):
         super().__init__("Remove %s" % node.title, parent)
         self.scheme = scheme
         self.node = node
-
+        self._index = -1
         links = scheme.input_links(self.node) + \
                 scheme.output_links(self.node)
 
@@ -108,10 +108,12 @@ class RemoveNodeCommand(UndoCommand):
     def redo(self):
         # redo child commands
         super().redo()
+        self._index = self.scheme.nodes.index(self.node)
         self.scheme.remove_node(self.node)
 
     def undo(self):
-        self.scheme.add_node(self.node)
+        assert self._index != -1
+        self.scheme.insert_node(self._index, self.node)
         # Undo child commands
         super().undo()
 
@@ -136,12 +138,16 @@ class RemoveLinkCommand(UndoCommand):
         super().__init__("Remove link", parent)
         self.scheme = scheme
         self.link = link
+        self._index = -1
 
     def redo(self):
+        self._index = self.scheme.links.index(self.link)
         self.scheme.remove_link(self.link)
 
     def undo(self):
-        self.scheme.add_link(self.link)
+        assert self._index != -1
+        self.scheme.insert_link(self._index, self.link)
+        self._index = -1
 
 
 class InsertNodeCommand(UndoCommand):
@@ -181,12 +187,16 @@ class RemoveAnnotationCommand(UndoCommand):
         super().__init__("Remove annotation", parent)
         self.scheme = scheme
         self.annotation = annotation
+        self._index = -1
 
     def redo(self):
+        self._index = self.scheme.annotations.index(self.annotation)
         self.scheme.remove_annotation(self.annotation)
 
     def undo(self):
-        self.scheme.add_annotation(self.annotation)
+        assert self._index != -1
+        self.scheme.insert_annotation(self._index, self.annotation)
+        self._index = -1
 
 
 class MoveNodeCommand(UndoCommand):

--- a/orangecanvas/scheme/events.py
+++ b/orangecanvas/scheme/events.py
@@ -106,11 +106,13 @@ class NodeEvent(WorkflowEvent):
     ----------
     etype: QEvent.Type
     node: SchemeNode
+    pos: int
     """
-    def __init__(self, etype, node):
-        # type: (QEvent.Type, SchemeNode) -> None
+    def __init__(self, etype, node, pos=-1):
+        # type: (QEvent.Type, SchemeNode, int) -> None
         super().__init__(etype)
         self.__node = node
+        self.__pos = pos
 
     def node(self):
         # type: () -> SchemeNode
@@ -121,6 +123,15 @@ class NodeEvent(WorkflowEvent):
             The node instance.
         """
         return self.__node
+
+    def pos(self) -> int:
+        """
+        For NodeAdded/NodeRemoved events this is the position into which the
+        node is inserted or removed from (is -1 if not applicable))
+
+        .. versionadded:: 0.1.16
+        """
+        return self.__pos
 
 
 class LinkEvent(WorkflowEvent):
@@ -143,11 +154,14 @@ class LinkEvent(WorkflowEvent):
     etype: QEvent.Type
     link: SchemeLink
         The link subject to change
+    pos: int
+        The link position index.
     """
-    def __init__(self, etype, link):
-        # type: (QEvent.Type, SchemeLink) -> None
+    def __init__(self, etype, link, pos=-1):
+        # type: (QEvent.Type, SchemeLink, int) -> None
         super().__init__(etype)
         self.__link = link
+        self.__pos = pos
 
     def link(self):
         # type: () -> SchemeLink
@@ -158,6 +172,23 @@ class LinkEvent(WorkflowEvent):
             The link instance.
         """
         return self.__link
+
+    def pos(self) -> int:
+        """
+        The index position into which the link was inserted.
+
+        For LinkAdded/LinkRemoved this is the index in the `Scheme.links`
+        sequence from which the link was removed or was inserted into.
+
+        For InputLinkAdded/InputLinkRemoved it is the sequential position in
+        the input links to the sink node.
+
+        For OutputLinkAdded/OutputLinkRemoved it is the sequential position in
+        the output links from the source node.
+
+        .. versionadded:: 0.1.16
+        """
+        return self.__pos
 
 
 class AnnotationEvent(WorkflowEvent):
@@ -174,11 +205,13 @@ class AnnotationEvent(WorkflowEvent):
     etype: QEvent.Type
     annotation: BaseSchemeAnnotation
         The annotation that is a subject of change.
+    pos: int
     """
-    def __init__(self, etype, annotation):
-        # type: (QEvent.Type, BaseSchemeAnnotation) -> None
+    def __init__(self, etype, annotation, pos=-1):
+        # type: (QEvent.Type, BaseSchemeAnnotation, int) -> None
         super().__init__(etype)
         self.__annotation = annotation
+        self.__pos = pos
 
     def annotation(self):
         # type: () -> BaseSchemeAnnotation
@@ -189,6 +222,14 @@ class AnnotationEvent(WorkflowEvent):
             The annotation instance.
         """
         return self.__annotation
+
+    def pos(self) -> int:
+        """
+        The index position of the annotation in the `Scheme.annotations`
+
+        .. versionadded:: 0.1.16
+        """
+        return self.__pos
 
 
 class WorkflowEnvChanged(WorkflowEvent):

--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -28,7 +28,7 @@ from .errors import (
     SchemeCycleError, IncompatibleChannelTypeError, SinkChannelError,
     DuplicatedLinkError
 )
-from .events import NodeEvent, LinkEvent, AnnotationEvent
+from .events import NodeEvent, LinkEvent, AnnotationEvent, WorkflowEnvChanged
 
 from ..registry import WidgetDescription, InputSignal, OutputSignal
 
@@ -785,6 +785,9 @@ class Scheme(QObject):
         oldvalue = self.__env.get(key, None)
         if value != oldvalue:
             self.__env[key] = value
+            QCoreApplication.sendEvent(
+                self, WorkflowEnvChanged(key, value, oldvalue)
+            )
             self.runtime_env_changed.emit(key, value, oldvalue)
 
     def get_runtime_env(self, key, default=None):

--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -9,7 +9,6 @@ The :class:`Scheme` class defines a DAG (Directed Acyclic Graph) workflow.
 import types
 import logging
 from contextlib import ExitStack
-from itertools import product
 from operator import itemgetter
 from collections import deque
 
@@ -20,18 +19,16 @@ from AnyQt.QtCore import QObject, QCoreApplication
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 
 from .node import SchemeNode
-from .link import SchemeLink, compatible_channels, resolved_valid_types, \
-    _classify_connection
+from .link import SchemeLink, compatible_channels, _classify_connection
 from .annotations import BaseSchemeAnnotation
 
-from ..utils import check_arg, type_lookup_
+from ..utils import check_arg, findf
 
 from .errors import (
     SchemeCycleError, IncompatibleChannelTypeError, SinkChannelError,
     DuplicatedLinkError
 )
-from . import events
-
+from .events import NodeEvent, LinkEvent, AnnotationEvent
 
 from ..registry import WidgetDescription, InputSignal, OutputSignal
 
@@ -215,7 +212,7 @@ class Scheme(QObject):
                   "Node already in scheme.")
         self.__nodes.insert(index, node)
 
-        ev = events.NodeEvent(events.NodeEvent.NodeAdded, node)
+        ev = NodeEvent(NodeEvent.NodeAdded, node, index)
         QCoreApplication.sendEvent(self, ev)
 
         log.info("Added node %r to scheme %r." % (node.title, self.title))
@@ -276,8 +273,9 @@ class Scheme(QObject):
                   "Node is not in the scheme.")
 
         self.__remove_node_links(node)
-        self.__nodes.remove(node)
-        ev = events.NodeEvent(events.NodeEvent.NodeRemoved, node)
+        index = self.__nodes.index(node)
+        self.__nodes.pop(index)
+        ev = NodeEvent(NodeEvent.NodeRemoved, node, index)
         QCoreApplication.sendEvent(self, ev)
         log.info("Removed node %r from scheme %r." % (node.title, self.title))
         self.node_removed.emit(node)
@@ -305,10 +303,28 @@ class Scheme(QObject):
         assert isinstance(link, SchemeLink)
         self.check_connect(link)
         self.__links.insert(index, link)
-
-        ev = events.LinkEvent(events.LinkEvent.LinkAdded, link)
-        QCoreApplication.sendEvent(self, ev)
-
+        source_index, _ = findf(
+            enumerate(self.find_links(source_node=link.source_node)),
+            lambda t: t[1] == link,
+            default=(-1, None)
+        )
+        sink_index, _ = findf(
+            enumerate(self.find_links(sink_node=link.sink_node)),
+            lambda t: t[1] == link,
+            default=(-1, None)
+        )
+        assert sink_index != -1 and source_index != -1
+        QCoreApplication.sendEvent(
+            link.source_node,
+            LinkEvent(LinkEvent.OutputLinkAdded, link, source_index)
+        )
+        QCoreApplication.sendEvent(
+            link.sink_node,
+            LinkEvent(LinkEvent.InputLinkAdded, link, sink_index)
+        )
+        QCoreApplication.sendEvent(
+            self, LinkEvent(LinkEvent.LinkAdded, link, index)
+        )
         log.info("Added link %r (%r) -> %r (%r) to scheme %r." % \
                  (link.source_node.title, link.source_channel.name,
                   link.sink_node.title, link.sink_channel.name,
@@ -373,10 +389,30 @@ class Scheme(QObject):
         """
         check_arg(link in self.__links,
                   "Link is not in the scheme.")
-
-        self.__links.remove(link)
-        ev = events.LinkEvent(events.LinkEvent.LinkRemoved, link)
-        QCoreApplication.sendEvent(self, ev)
+        source_index, _ = findf(
+            enumerate(self.find_links(source_node=link.source_node)),
+            lambda t: t[1] == link,
+            default=(-1, None)
+        )
+        sink_index, _ = findf(
+            enumerate(self.find_links(sink_node=link.sink_node)),
+            lambda t: t[1] == link,
+            default=(-1, None)
+        )
+        assert sink_index != -1 and source_index != -1
+        index = self.__links.index(link)
+        self.__links.pop(index)
+        QCoreApplication.sendEvent(
+            link.sink_node,
+            LinkEvent(LinkEvent.InputLinkRemoved, link, sink_index)
+        )
+        QCoreApplication.sendEvent(
+            link.source_node,
+            LinkEvent(LinkEvent.OutputLinkRemoved, link, source_index)
+        )
+        QCoreApplication.sendEvent(
+            self, LinkEvent(LinkEvent.LinkRemoved, link, index)
+        )
         log.info("Removed link %r (%r) -> %r (%r) from scheme %r." % \
                  (link.source_node.title, link.source_channel.name,
                   link.sink_node.title, link.sink_channel.name,
@@ -654,8 +690,8 @@ class Scheme(QObject):
         if annotation in self.__annotations:
             raise ValueError("Cannot add the same annotation multiple times")
         self.__annotations.insert(index, annotation)
-        ev = events.AnnotationEvent(events.AnnotationEvent.AnnotationAdded,
-                                    annotation)
+        ev = AnnotationEvent(AnnotationEvent.AnnotationAdded,
+                             annotation, index)
         QCoreApplication.sendEvent(self, ev)
         self.annotation_inserted.emit(index, annotation)
         self.annotation_added.emit(annotation)
@@ -673,12 +709,11 @@ class Scheme(QObject):
         """
         Remove the `annotation` instance from the scheme.
         """
-        self.__annotations.remove(annotation)
-
-        ev = events.AnnotationEvent(events.AnnotationEvent.AnnotationRemoved,
-                                    annotation)
+        index = self.__annotations.index(annotation)
+        self.__annotations.pop(index)
+        ev = AnnotationEvent(AnnotationEvent.AnnotationRemoved,
+                             annotation, index)
         QCoreApplication.sendEvent(self, ev)
-
         self.annotation_removed.emit(annotation)
 
     def clear(self):

--- a/orangecanvas/scheme/tests/test_scheme.py
+++ b/orangecanvas/scheme/tests/test_scheme.py
@@ -1,6 +1,7 @@
 """
 Tests for Scheme
 """
+from AnyQt.QtTest import QSignalSpy
 
 from ...gui import test
 from ...registry.tests import small_testing_registry
@@ -110,3 +111,43 @@ class TestScheme(test.QCoreAppTestCase):
         scheme.remove_annotation(text_annot)
         self.assertSequenceEqual(annotations_added, [arrow_annot])
         self.assertSequenceEqual(scheme.annotations, annotations_added)
+
+    def test_insert_node(self):
+        reg = small_testing_registry()
+        one_desc = reg.widget("one")
+        n1, n2 = SchemeNode(one_desc), SchemeNode(one_desc)
+        w = Scheme()
+        spy = QSignalSpy(w.node_inserted)
+        w.add_node(n1)
+        w.insert_node(0, n2)
+        self.assertSequenceEqual(list(spy), [[0, n1], [0, n2]])
+        self.assertSequenceEqual(w.nodes, [n2, n1])
+
+    def test_insert_link(self):
+        reg = small_testing_registry()
+        one_desc = reg.widget("one")
+        add_desc = reg.widget("add")
+        n1, n2, n3 = SchemeNode(one_desc), SchemeNode(one_desc), SchemeNode(add_desc)
+        w = Scheme()
+        spy = QSignalSpy(w.link_inserted)
+        w.add_node(n1)
+        w.add_node(n2)
+        w.add_node(n3)
+        l1 = SchemeLink(n1, "value", n3, "left")
+        l2 = SchemeLink(n2, "value", n3, "right")
+        w.add_link(l1)
+        w.insert_link(0, l2)
+        self.assertSequenceEqual(list(spy), [[0, l1], [0, l2]])
+        self.assertSequenceEqual(w.links, [l2, l1])
+
+    def test_insert_annotation(self):
+        w = Scheme()
+        a1 = SchemeTextAnnotation((0, 0, 1, 1), "a1")
+        a2 = SchemeTextAnnotation((0, 0, 1, 1), "a2")
+        a3 = SchemeTextAnnotation((0, 0, 1, 1), "a3")
+        spy = QSignalSpy(w.annotation_inserted)
+        w.insert_annotation(0, a1)
+        w.insert_annotation(1, a2)
+        w.insert_annotation(0, a3)
+        self.assertSequenceEqual(w.annotations, [a3, a1, a2])
+        self.assertSequenceEqual(list(spy), [[0, a1], [1, a2], [0, a3]])

--- a/orangecanvas/scheme/tests/test_widgetmanager.py
+++ b/orangecanvas/scheme/tests/test_widgetmanager.py
@@ -1,7 +1,7 @@
-from PyQt5.QtCore import QEvent
-
 import unittest
+from collections import Counter
 
+from AnyQt.QtCore import QEvent
 from AnyQt.QtWidgets import QWidget, QApplication, QAction
 from AnyQt.QtTest import QSignalSpy
 
@@ -171,25 +171,34 @@ class TestWidgetManager(unittest.TestCase):
         l1, l2 = links[:2]
         w1 = wm.widget_for_node(n1)
 
-        self.assertIn(NodeEvent.OutputLinkAdded, w1._evt)
+        self.assertInWithCount(NodeEvent.OutputLinkAdded, w1._evt, 1)
         w1._evt.clear()
         workflow.remove_link(l1)
 
-        self.assertIn(NodeEvent.OutputLinkRemoved, w1._evt)
+        self.assertInWithCount(NodeEvent.OutputLinkRemoved, w1._evt, 1)
         w3 = wm.widget_for_node(n3)
         w3._evt.clear()
         workflow.add_link(l1)
-        self.assertIn(NodeEvent.OutputLinkAdded, w1._evt)
-        self.assertIn(NodeEvent.InputLinkAdded, w3._evt)
+        self.assertInWithCount(NodeEvent.OutputLinkAdded, w1._evt, 1)
+        self.assertInWithCount(NodeEvent.InputLinkAdded, w3._evt, 1)
 
         w1._evt.clear()
         workflow.set_runtime_env("tt", "aaa")
-        self.assertIn(NodeEvent.WorkflowEnvironmentChange, w1._evt)
+        self.assertInWithCount(NodeEvent.WorkflowEnvironmentChange, w1._evt, 1)
 
         w3._evt.clear()
         l1.set_runtime_state(SchemeLink.Pending)
-        self.assertIn(LinkEvent.InputLinkStateChange, w3._evt)
-        self.assertIn(LinkEvent.OutputLinkStateChange, w1._evt)
+        self.assertInWithCount(LinkEvent.InputLinkStateChange, w3._evt, 1)
+        self.assertInWithCount(LinkEvent.OutputLinkStateChange, w1._evt, 1)
+
+    def assertInWithCount(self, member, container, expected):
+        counter = Counter(container)
+        count = counter[member]
+        if count != expected:
+            msg = "Count of %s in %s is %i; expected %i" % (
+                member, container, count, expected
+            )
+            self.fail(msg)
 
     def test_actions(self):
         workflow = self.scheme

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -16,9 +16,7 @@ from AnyQt.QtGui import QKeySequence
 from AnyQt.QtWidgets import QWidget, QLabel, QAction
 
 from orangecanvas.resources import icon_loader
-from orangecanvas.scheme import (
-    SchemeNode, Scheme, NodeEvent, SchemeLink, LinkEvent
-)
+from orangecanvas.scheme import SchemeNode, Scheme, NodeEvent, LinkEvent
 from orangecanvas.scheme.events import WorkflowEvent, WorkflowEnvChanged
 from orangecanvas.scheme.node import UserMessage
 
@@ -127,8 +125,6 @@ class WidgetManager(QObject):
                 self.__remove_node(node)
             self.__workflow.node_added.disconnect(self.__on_node_added)
             self.__workflow.node_removed.disconnect(self.__on_node_removed)
-            self.__workflow.link_added.disconnect(self.__on_link_added)
-            self.__workflow.link_removed.disconnect(self.__on_link_removed)
             self.__workflow.runtime_env_changed.disconnect(self.__on_env_changed)
             self.__workflow.removeEventFilter(self)
 
@@ -138,10 +134,6 @@ class WidgetManager(QObject):
             self.__on_node_added, Qt.UniqueConnection)
         workflow.node_removed.connect(
             self.__on_node_removed, Qt.UniqueConnection)
-        workflow.link_added.connect(
-            self.__on_link_added, Qt.UniqueConnection)
-        workflow.link_removed.connect(
-            self.__on_link_removed, Qt.UniqueConnection)
         workflow.runtime_env_changed.connect(
             self.__on_env_changed, Qt.UniqueConnection)
         workflow.installEventFilter(self)
@@ -302,12 +294,12 @@ class WidgetManager(QObject):
         workflow = self.__workflow
         assert workflow is not None
         inputs = workflow.find_links(sink_node=node)
-        for link in inputs:
-            ev = LinkEvent(LinkEvent.InputLinkAdded, link)
+        for i, link in enumerate(inputs):
+            ev = LinkEvent(LinkEvent.InputLinkAdded, link, i)
             QCoreApplication.sendEvent(w, ev)
         outputs = workflow.find_links(source_node=node)
-        for link in outputs:
-            ev = LinkEvent(LinkEvent.OutputLinkAdded, link)
+        for i, link in enumerate(outputs):
+            ev = LinkEvent(LinkEvent.OutputLinkAdded, link, i)
             QCoreApplication.sendEvent(w, ev)
 
         self.widget_for_node_added.emit(node, w)
@@ -379,34 +371,6 @@ class WidgetManager(QObject):
             finally:
                 if self.__init_queue:
                     self.__init_timer.start()
-
-    def __on_link_added(self, link):  # type: (SchemeLink) -> None
-        assert self.__workflow is not None
-        assert link.source_node in self.__workflow.nodes
-        assert link.sink_node in self.__workflow.nodes
-        source = self.__item_for_node.get(link.source_node)
-        sink = self.__item_for_node.get(link.sink_node)
-        # notify the node gui of an added link
-        if source is not None and source.widget is not None:
-            ev = LinkEvent(LinkEvent.OutputLinkAdded, link)
-            QCoreApplication.sendEvent(source.widget, ev)
-        if sink is not None and sink.widget is not None:
-            ev = LinkEvent(LinkEvent.InputLinkAdded, link)
-            QCoreApplication.sendEvent(sink.widget, ev)
-
-    def __on_link_removed(self, link):  # type: (SchemeLink) -> None
-        assert self.__workflow is not None
-        assert link.source_node in self.__workflow.nodes
-        assert link.sink_node in self.__workflow.nodes
-        source = self.__item_for_node.get(link.source_node)
-        sink = self.__item_for_node.get(link.sink_node)
-        # notify the node gui of an removed link
-        if source is not None and source.widget is not None:
-            ev = LinkEvent(LinkEvent.OutputLinkRemoved, link)
-            QCoreApplication.sendEvent(source.widget, ev)
-        if sink is not None and sink.widget is not None:
-            ev = LinkEvent(LinkEvent.InputLinkRemoved, link)
-            QCoreApplication.sendEvent(sink.widget, ev)
 
     def __mark_activated(self, widget):  # type: (QWidget) ->  None
         # Update the tracked stacking order for `widget`
@@ -594,7 +558,7 @@ class WidgetManager(QObject):
 
     def eventFilter(self, recv, event):
         # type: (QObject, QEvent) -> bool
-        if isinstance(recv, SchemeNode):
+        if isinstance(recv, SchemeNode) and recv in self.__item_for_node:
             if event.type() == NodeEvent.NodeActivateRequest:
                 self.__activate_widget_for_node(recv)
             self.__dispatch_events(recv, event)


### PR DESCRIPTION
#### Issue

Undo/redo of node, link and annotations removal does not preserve their order in the underlying model.
I.e. redo of a remove action always places the respective element at last position.

#### Changes

* Extend Scheme class with insert_{node,link,annotation} methods
* Make Remove{Node,Link,Annotation}Command insert the element at the appropriate place.