### PR TITLE
[RFC][NOMERGE] Colored links

### DIFF
--- a/orangecanvas/canvas/items/linkitem.py
+++ b/orangecanvas/canvas/items/linkitem.py
@@ -16,7 +16,7 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtGui import (
     QPen, QBrush, QColor, QPainterPath, QTransform, QPalette,
-)
+    QPainterPathStroker, QPainter)
 from AnyQt.QtCore import Qt, QPointF, QRectF, QLineF, QEvent, QPropertyAnimation, Signal, QTimer
 
 from .nodeitem import AnchorPoint, SHADOW_COLOR
@@ -118,9 +118,18 @@ class LinkCurveItem(QGraphicsPathItem):
         if self.__animationEnabled != enabled:
             self.__animationEnabled = enabled
 
+    def paint(self, painter: QPainter, option, widget=None):
+        if self.__hover:
+            spath = stroke_path(self.path(), self.pen())
+            painter.save()
+            painter.setPen(QPen(QColor("#959595"), 2))
+            painter.drawPath(spath)
+            painter.restore()
+        super().paint(painter, option, widget)
+
     def __update(self):
         # type: () -> None
-        radius = 5 if self.__hover else 0
+        radius = 7 if self.__hover else 0
 
         if radius != 0 and not self.shadow.isEnabled():
             self.shadow.setEnabled(True)
@@ -757,7 +766,8 @@ class LinkItem(QGraphicsWidget):
             hover = QPen(QBrush(color.darker(120)), 2.0)
         else:
             normal = QPen(QBrush(QColor("#9CACB4")), 2.0)
-            hover = QPen(QBrush(QColor("#959595")), 2.0)
+            hover = QPen(QBrush(QColor("#FFD39F")), 5.0)
+            hover.setCapStyle(Qt.RoundCap)
 
         if self.__state & LinkItem.Empty:
             pen_style = Qt.DashLine


### PR DESCRIPTION
#116

A quick and dirty example of how links could be colored based on their type. This PR treats all links as if they're data links, but the color would change if the link were of signal type Model (purple), Learner (pink), Corpus (blue). Maybe a short animation expanding the link could be added too.

Coupled with the changes in #114, I think we can breathe some new life into the canvas.

![ezgif-7-4f9466ac3aaf](https://user-images.githubusercontent.com/24586651/92281603-35ccb980-eefc-11ea-9e1d-f4b694657f9d.gif)

(also I'll clean up this module because it's a bit messy as is)

