### PR TITLE
setup.py: Specify minimum bound for commonmark version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ INSTALL_REQUIRES = (
     "setuptools",
     "AnyQt",
     "docutils",
-    "commonmark",
+    "commonmark>=0.8.1",
     "requests",
     "cachecontrol[filecache]",
     "pip>=18.0",


### PR DESCRIPTION
#### Issue

`markup.render_markdown` only works with commonmark>=0.8.1

Ref: gh-111

#### Changes

Specify a lower version bound for `commonmark` in dependencies.

