### PR TITLE
toolbox: Update geometry on scrollbar style (transient) changed

### DIFF
--- a/orangecanvas/gui/toolbox.py
+++ b/orangecanvas/gui/toolbox.py
@@ -24,8 +24,8 @@ from AnyQt.QtCore import (
 )
 from AnyQt.QtCore import Signal, Property
 
-from .utils import brush_darker
 from ..utils import set_flag
+from .utils import brush_darker, ScrollBar
 
 __all__ = [
     "ToolBox"
@@ -304,6 +304,9 @@ class ToolBox(QFrame):
             horizontalScrollBarPolicy=Qt.ScrollBarAlwaysOff,
             widgetResizable=True,
         )
+        sb = ScrollBar()
+        sb.styleChange.connect(self.updateGeometry)
+        self.__scrollArea.setVerticalScrollBar(sb)
         self.__scrollArea.setFrameStyle(QScrollArea.NoFrame)
 
         # A widget with all of the contents.

--- a/orangecanvas/gui/utils.py
+++ b/orangecanvas/gui/utils.py
@@ -9,13 +9,13 @@ import ctypes
 from contextlib import contextmanager
 
 from AnyQt.QtWidgets import (
-    QWidget, QMessageBox, QStyleOption, QStyle, QTextEdit
+    QWidget, QMessageBox, QStyleOption, QStyle, QTextEdit, QScrollBar
 )
 from AnyQt.QtGui import (
     QGradient, QLinearGradient, QRadialGradient, QBrush, QPainter,
     QPaintEvent, QColor, QPixmap, QPixmapCache, QTextOption
 )
-from AnyQt.QtCore import Qt, QPointF, QPoint, QRect, QRectF
+from AnyQt.QtCore import Qt, QPointF, QPoint, QRect, QRectF, Signal, QEvent
 
 import sip
 
@@ -73,6 +73,16 @@ class StyledWidget(QWidget):
     """
     """
     paintEvent = StyledWidget_paintEvent  # type: ignore
+
+
+class ScrollBar(QScrollBar):
+    #: Emitted when the scroll bar receives a StyleChange event
+    styleChange = Signal()
+
+    def changeEvent(self, event: QEvent) -> None:
+        if event.type() == QEvent.StyleChange:
+            self.styleChange.emit()
+        super().changeEvent(event)
 
 
 def is_transparency_supported():  # type: () -> bool


### PR DESCRIPTION
On Mac, a mouse plugged in and 'Show scroll bars automatically based on mouse or trackpad' selected in General System Preferences, the `SH_ScrollBar_Transient` style hint will at first act as if the scrollbar is transient. After a few moments, it will correctly report that the scrollbar is not transient. This resulted in the toolbox being slightly obscured by the scrollbar.

This change stores the sizehint in the instance, and schedules a geometry update if it's changed, correctly updating the size of the toolbox.