### PR TITLE
Import MutableMapping from typing, not collections

### DIFF
--- a/orangecanvas/utils/settings.py
+++ b/orangecanvas/utils/settings.py
@@ -10,8 +10,8 @@ import logging
 
 import typing
 from typing import List, Dict, Tuple, Union, Any, Type, Optional
-
-from collections import namedtuple, MutableMapping
+from collections import namedtuple
+from collections.abc import MutableMapping
 
 from AnyQt.QtCore import QObject, QEvent, QCoreApplication, QSettings
 from AnyQt.QtCore import pyqtSignal as Signal


### PR DESCRIPTION
*Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working.*