### PR TITLE
canvasmain: Don't delete swp on swp load

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1720,11 +1720,6 @@ class CanvasMainWindow(QMainWindow):
                 "Could not load restore data.", title="Error", exc_info=True,
             )
             return
-        else:
-            try:
-                os.remove(filename)
-            except OSError:
-                pass
 
         document.undoCommandAdded.disconnect(self.save_swp)
 


### PR DESCRIPTION
This is unnecessary, the swp file is cleared when the workflow is saved/closed. With the current behavior, if the swp is restored (and deleted), and Orange crashes again (likely to happen if it's crashed at this point before), the swp is lost.