### PR TITLE
[RFC] Redesign toolbox with smaller icons and no text 

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -268,8 +268,8 @@ class CanvasMainWindow(QMainWindow):
         self.widgets_tool_box.setObjectName("canvas-toolbox")
         self.widgets_tool_box.setTabButtonHeight(30)
         self.widgets_tool_box.setTabIconSize(QSize(26, 26))
-        self.widgets_tool_box.setButtonSize(QSize(64, 84))
-        self.widgets_tool_box.setIconSize(QSize(48, 48))
+        self.widgets_tool_box.setButtonSize(QSize(42, 42))
+        self.widgets_tool_box.setIconSize(QSize(36, 36))
 
         self.widgets_tool_box.triggered.connect(
             self.on_tool_box_widget_activated
@@ -317,8 +317,6 @@ class CanvasMainWindow(QMainWindow):
         self.canvas_arrow_action.setIcon(canvas_icons("Arrow.svg"))
 
         dock_actions = [
-            self.show_properties_action,
-            self.canvas_align_to_grid_action,
             self.canvas_text_action,
             self.canvas_arrow_action,
             self.freeze_action,

--- a/orangecanvas/application/canvastooldock.py
+++ b/orangecanvas/application/canvastooldock.py
@@ -231,6 +231,11 @@ class QuickHelpWidget(QuickHelp):
         hint = super().minimumSizeHint()
         return QSize(hint.width(), 0)
 
+    def sizeHint(self):
+        minSh = self.minimumSizeHint()
+        sh = super().sizeHint()
+        return QSize(minSh.width(), sh.height())
+
 
 class CanvasToolDock(QWidget):
     """Canvas dock widget with widget toolbox, quick help and

--- a/orangecanvas/application/widgettoolbox.py
+++ b/orangecanvas/application/widgettoolbox.py
@@ -80,6 +80,7 @@ class WidgetToolGrid(ToolGrid):
     def __init__(self, *args, **kwargs):
         # type: (Any, Any) -> None
         super().__init__(*args, **kwargs)
+        self.setContentsMargins(3, 3, 3, 3)
 
         self.__model = None               # type: Optional[QAbstractItemModel]
         self.__rootIndex = QModelIndex()  # type: QModelIndex

--- a/orangecanvas/gui/toolbox.py
+++ b/orangecanvas/gui/toolbox.py
@@ -544,7 +544,7 @@ class ToolBox(QFrame):
             hint = QSize(max(max_w, hint.width()) + scroll_w + frame_w,
                          hint.height())
 
-        return QSize(200, 200).expandedTo(hint)
+        return hint
 
     def __onTabActionToggled(self, action):
         # type: (QAction) -> None


### PR DESCRIPTION
Changes:
- smaller icons
- no text below icons
- workflow info and align to grid buttons removed

Workflow info is accessible by `CMD+I` and `File -> Workflow Info`. I suppose align to grid should be added to one of the top menus. I don't find the action useful as it is right now, I think it should either be removed or replaced with the idea originally described in biolab/orange3#4154.

Also, I've changed ToolGrid to inherit QWidget instead of QFrame. This was the only way I could find which removes an annoying 8-pixel bottom margin. Does this break anything?

<img width="1072" alt="Screenshot 2020-09-21 at 23 34 20" src="https://user-images.githubusercontent.com/24586651/93823968-fc69ad00-fc62-11ea-84e7-24da56caf0ca.png">
