### PR TITLE
application: Show shortcuts in context menus on PyQt5.13 and up

### DIFF
--- a/orangecanvas/application/application.py
+++ b/orangecanvas/application/application.py
@@ -101,6 +101,10 @@ class CanvasApplication(QApplication):
         super().__init__(argv_)
         argv[:] = argv_
         self.setAttribute(Qt.AA_DontShowIconsInMenus, True)
+        sh = self.styleHints()
+        if hasattr(sh, 'setShowShortcutsInContextMenus'):
+            # PyQt5.13 and up
+            sh.setShowShortcutsInContextMenus(True)
         self.configureStyle()
 
     def event(self, event):


### PR DESCRIPTION
PyQt5 is weird, this needs to be set for it to show shortcuts in menus (that aren't in the menubar) by default. 
I did this so it shows up when you right-click a widget on canvas, but it'll probably affect menus elsewhere too.