### PR TITLE
Fix swp duplication upon loading swp file

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -74,7 +74,8 @@ from ..registry import WidgetRegistry, WidgetDescription, CategoryDescription
 from ..registry.qt import QtWidgetRegistry
 from ..utils.settings import QSettings_readArray, QSettings_writeArray
 from ..utils.qinvoke import qinvoke
-from ..utils.pickle import Pickler, Unpickler, glob_scratch_swps, swp_name, canvas_scratch_name_memo
+from ..utils.pickle import Pickler, Unpickler, glob_scratch_swps, swp_name, \
+    canvas_scratch_name_memo, register_loaded_swp
 from ..utils import unique, group_by_all, set_flag
 
 from . import welcomedialog
@@ -1724,6 +1725,8 @@ class CanvasMainWindow(QMainWindow):
                 "Could not load restore data.", title="Error", exc_info=True,
             )
             return
+
+        register_loaded_swp(self, filename)
 
         document.undoCommandAdded.disconnect(self.save_swp)
 

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1724,6 +1724,13 @@ class CanvasMainWindow(QMainWindow):
             message_critical(
                 "Could not load restore data.", title="Error", exc_info=True,
             )
+
+            # delete corrupted swp file
+            try:
+                os.remove(filename)
+            except OSError:
+                pass
+
             return
 
         register_loaded_swp(self, filename)

--- a/orangecanvas/utils/pickle.py
+++ b/orangecanvas/utils/pickle.py
@@ -80,6 +80,10 @@ def swp_name(canvas):
     return swpname
 
 
+def register_loaded_swp(canvas, swpname):
+    canvas_scratch_name_memo[canvas] = swpname
+
+
 def glob_scratch_swps():
     swpname = scratch_swp_base_name()
     return glob.glob(swpname + ".*")


### PR DESCRIPTION
Fixes a bug introduced by #131. 

Loading a swp and making a change resulted in another swp file being created. This change correctly associates the canvas instance with the loaded swp file.