### PR TITLE
Crash recovery fixes

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1488,7 +1488,6 @@ class CanvasMainWindow(QMainWindow):
         if filename:
             settings.setValue("last-scheme-dir", os.path.dirname(filename))
             if self.save_scheme_to(curr_scheme, filename):
-                self.clear_swp()
                 document.setPath(filename)
                 document.setModified(False)
                 self.add_recent_scheme(curr_scheme.title, document.path())
@@ -1527,6 +1526,7 @@ class CanvasMainWindow(QMainWindow):
         try:
             with open(filename, "wb") as f:
                 f.write(buffer.getvalue())
+            self.clear_swp()
             return True
         except FileNotFoundError as ex:
             log.error("%s saving '%s'", type(ex).__name__, filename,

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1173,7 +1173,7 @@ class CanvasMainWindow(QMainWindow):
             mb.open()
 
         if new_scheme is not None:
-            self.set_scheme(new_scheme)
+            self.set_scheme(new_scheme, freeze_creation=True)
 
             scheme_doc_widget = self.current_document()
             scheme_doc_widget.setPath(filename)
@@ -1184,6 +1184,10 @@ class CanvasMainWindow(QMainWindow):
                 scheme_doc_widget.activateDefaultWindowGroup()
 
             self.ask_load_swp_if_exists()
+
+            wm = getattr(new_scheme, "widget_manager", None)
+            if wm is not None:
+                wm.set_creation_policy(wm.Normal)
 
     def new_scheme_from(self, filename):
         # type: (str) -> Optional[Scheme]

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -182,6 +182,9 @@ class SchemeEditWidget(QWidget):
         # list of links when set to a clean state
         self.__cleanLinks = []
 
+        # list of annotations when set to a clean state
+        self.__cleanAnnotations = []
+
         self.__editFinishedMapper = QSignalMapper(self)
         self.__editFinishedMapper.mapped[QObject].connect(
             self.__onEditingFinished
@@ -609,14 +612,17 @@ class SchemeEditWidget(QWidget):
         if not modified:
             if self.__scheme:
                 self.__cleanProperties = node_properties(self.__scheme)
-                self.__cleanLinks = list(self.__scheme.links)
+                self.__cleanLinks = self.__scheme.links
+                self.__cleanAnnotations = self.__scheme.annotations
             else:
                 self.__cleanProperties = {}
                 self.__cleanLinks = []
+                self.__cleanAnnotations = []
             self.__undoStack.setClean()
         else:
             self.__cleanProperties = {}
             self.__cleanLinks = []
+            self.__cleanAnnotations = []
 
     modified = Property(bool, fget=isModified, fset=setModified)
 
@@ -677,6 +683,9 @@ class SchemeEditWidget(QWidget):
 
     def cleanLinks(self):
         return self.__cleanLinks
+
+    def cleanAnnotations(self):
+        return self.__cleanAnnotations
 
     def setQuickMenuTriggers(self, triggers):
         # type: (int) -> None
@@ -799,7 +808,8 @@ class SchemeEditWidget(QWidget):
                     self.__reset_window_group_menu
                 )
                 self.__cleanProperties = node_properties(scheme)
-                self.__cleanLinks = list(scheme.links)
+                self.__cleanLinks = scheme.links
+                self.__cleanAnnotations = scheme.annotations
                 sm = scheme.findChild(signalmanager.SignalManager)
                 if sm:
                     sm.stateChanged.connect(self.__signalManagerStateChanged)
@@ -813,6 +823,7 @@ class SchemeEditWidget(QWidget):
             else:
                 self.__cleanProperties = {}
                 self.__cleanLinks = []
+                self.__cleanAnnotations = []
 
             self.__teardownScene(self.__scene)
             self.__scene.deleteLater()

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -644,17 +644,27 @@ class SchemeEditWidget(QWidget):
         Returns node properties differences since last clean state,
         excluding unclean nodes.
         """
+
         currentProperties = node_properties(self.__scheme)
+        # ignore diff for newly created nodes
+        cleanNodes = self.cleanNodes()
         currentCleanNodeProperties = {k: v
                                       for k, v in currentProperties.items()
-                                      if k in self.cleanNodes()}
+                                      if k in cleanNodes}
+
+        cleanProperties = self.__cleanProperties
+        # ignore diff for deleted nodes
+        currentNodes = self.__scheme.nodes
+        cleanCurrentNodeProperties = {k: v
+                                      for k, v in cleanProperties.items()
+                                      if k in currentNodes}
 
         # ignore contexts
         ignore = set((node, "context_settings")
                      for node in currentCleanNodeProperties.keys())
 
         return list(dictdiffer.diff(
-            self.__cleanProperties,
+            cleanCurrentNodeProperties,
             currentCleanNodeProperties,
             ignore=ignore
         ))

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -676,7 +676,10 @@ class SchemeEditWidget(QWidget):
         ))
 
     def restoreProperties(self, dict_diff):
-        dictdiffer.patch(dict_diff, node_properties(self.__scheme), in_place=True)
+        ref_properties = {
+            node: node.properties for node in self.__scheme.nodes
+        }
+        dictdiffer.patch(dict_diff, ref_properties, in_place=True)
 
     def cleanNodes(self):
         return list(self.__cleanProperties.keys())

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -96,7 +96,7 @@ class WidgetManager(QObject):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__workflow = None  # type: Optional[Scheme]
-        self.__creation_policy = WidgetManager.Normal
+        self.__creation_policy = WidgetManager.OnDemand
         self.__float_widgets_on_top = False
 
         self.__item_for_node = {}  # type: Dict[SchemeNode, Item]

--- a/orangecanvas/utils/pickle.py
+++ b/orangecanvas/utils/pickle.py
@@ -5,7 +5,7 @@ import pickle
 from PyQt5.QtCore import QSettings
 
 from orangecanvas import config
-from ..scheme import Scheme, SchemeNode, SchemeLink
+from ..scheme import Scheme, SchemeNode, SchemeLink, BaseSchemeAnnotation
 
 
 class Pickler(pickle.Pickler):
@@ -20,6 +20,8 @@ class Pickler(pickle.Pickler):
             return "SchemeNode_" + str(self.document.cleanNodes().index(obj))
         elif isinstance(obj, SchemeLink) and obj in self.document.cleanLinks():
             return "SchemeLink_" + str(self.document.cleanLinks().index(obj))
+        elif isinstance(obj, BaseSchemeAnnotation) and obj in self.document.cleanAnnotations():
+            return "BaseSchemeAnnotation_" + str(self.document.cleanAnnotations().index(obj))
         else:
             return None
 
@@ -38,6 +40,9 @@ class Unpickler(pickle.Unpickler):
         elif pid.startswith('SchemeLink_'):
             link_index = int(pid.split('_')[1])
             return self.scheme.links[link_index]
+        elif pid.startswith('BaseSchemeAnnotation_'):
+            annotation_index = int(pid.split('_')[1])
+            return self.scheme.annotations[annotation_index]
         else:
             raise pickle.UnpicklingError("Unsupported persistent object")
 


### PR DESCRIPTION
Regarding swp crash recovery:
- Add support for annotations
- Fix restoring node properties
- Fix deleting nodes
- Fix clearing swp on a type of workflow save