### PR TITLE
[ENH] Help refactor

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -46,10 +46,9 @@ import sip
 
 from orangecanvas.utils import unique, name_lookup, markup, qualified_name
 from orangecanvas.utils.shtools import python_process, create_process
-
+from ..utils.pkgmeta import get_dist_meta, parse_meta
 from ..utils.qinvoke import qinvoke
 from ..gui.utils import message_warning, message_critical as message_error
-from ..help.manager import get_dist_meta, parse_meta
 
 from .. import config
 from ..config import Config

--- a/orangecanvas/application/application.py
+++ b/orangecanvas/application/application.py
@@ -12,6 +12,8 @@ from AnyQt.QtCore import (
     Qt, QUrl, QEvent, QSettings, QLibraryInfo, pyqtSignal as Signal
 )
 
+from orangecanvas.utils.asyncutils import get_event_loop
+
 
 def fix_qt_plugins_path():
     """
@@ -99,6 +101,9 @@ class CanvasApplication(QApplication):
         if self.__args.style:
             argv_ = argv_ + ["-style", self.__args.style]
         super().__init__(argv_)
+        # Make sure there is an asyncio event loop that runs on the
+        # Qt event loop.
+        _ = get_event_loop()
         argv[:] = argv_
         self.setAttribute(Qt.AA_DontShowIconsInMenus, True)
         if hasattr(self, "styleHints"):

--- a/orangecanvas/application/tests/test_mainwindow.py
+++ b/orangecanvas/application/tests/test_mainwindow.py
@@ -2,11 +2,13 @@ import os
 import tempfile
 from unittest.mock import patch
 
-from AnyQt.QtWidgets import QToolButton, QDialog, QMessageBox
+from AnyQt.QtGui import QWhatsThisClickedEvent
+from AnyQt.QtWidgets import QToolButton, QDialog, QMessageBox, QApplication
 
 from .. import addons
 from ..outputview import TextStream
 from ...scheme import SchemeTextAnnotation, SchemeLink
+from ...gui.quickhelp import QuickHelpTipEvent, QuickHelp
 from ...utils.shtools import temp_named_file
 from ...utils.pickle import swp_name
 from ...gui.test import QAppTestCase
@@ -123,6 +125,19 @@ class TestMainWindow(TestMainWindowBase):
         new = w.create_new_window()
         self.assertEqual(len(new.recent_schemes), 1)
         w.clear_recent_schemes()
+
+    def test_quick_help_events(self):
+        w = self.w
+        help: QuickHelp = w.dock_help
+        html = "<h3>HELLO</h3>"
+        ev = QuickHelpTipEvent("", html, priority=QuickHelpTipEvent.Normal)
+        QApplication.sendEvent(w, ev)
+        self.assertEqual(help.currentText(), "<h3>HELLO</h3>")
+
+    def test_help_requests(self):
+        w = self.w
+        ev = QWhatsThisClickedEvent('help://search?id=one')
+        QApplication.sendEvent(w, ev)
 
 
 class TestMainWindowLoad(TestMainWindowBase):

--- a/orangecanvas/help/manager.py
+++ b/orangecanvas/help/manager.py
@@ -129,15 +129,6 @@ def qurl_query_items(url: QUrl) -> List[Tuple[str, str]]:
     return urllib.parse.parse_qsl(querystr)
 
 
-def get_help_provider_for_description(desc):
-    # type: (WidgetDescription) -> Optional[provider.HelpProvider]
-    if desc.project_name:
-        dist = pkg_resources.get_distribution(desc.project_name)
-        return get_help_provider_for_distribution(dist)
-    else:
-        return None
-
-
 def _replacements_for_dist(dist):
     # type: (Distribution) -> Dict[str, str]
     replacements = {"PROJECT_NAME": dist.project_name,

--- a/orangecanvas/help/manager.py
+++ b/orangecanvas/help/manager.py
@@ -307,7 +307,13 @@ def get_help_provider_for_distribution(dist):
     """
     if dist.project_name in _providers_cache:
         return _providers_cache[dist.project_name]
-    entry_points = dist.get_entry_map().get("orange.canvas.help", {})
+
+    eps = dist.get_entry_map()
+    entry_points = eps.get("orange.canvas.help", {})
+    if not entry_points:
+        # alternative name
+        entry_points = eps.get("orangecanvas.help", {})
+
     provider = None
     for name, entry_point in entry_points.items():
         create = _providers.get(name, None)

--- a/orangecanvas/help/manager.py
+++ b/orangecanvas/help/manager.py
@@ -1,16 +1,11 @@
 """
 
 """
-import sys
 import os
 import string
 import itertools
 import logging
-import email
 import urllib.parse
-
-from distutils.version import StrictVersion
-from operator import itemgetter
 from sysconfig import get_path
 
 import typing
@@ -20,6 +15,7 @@ import pkg_resources
 
 from AnyQt.QtCore import QObject, QUrl, QDir
 
+from ..utils.pkgmeta import get_dist_url, is_develop_egg
 from . import provider
 
 if typing.TYPE_CHECKING:
@@ -146,129 +142,6 @@ def get_help_provider_for_description(desc):
         return get_help_provider_for_distribution(dist)
     else:
         return None
-
-
-def is_develop_egg(dist):
-    # type: (Distribution) -> bool
-    """
-    Is the distribution installed in development mode (setup.py develop)
-    """
-    meta_provider = dist._provider
-    egg_info_dir = os.path.dirname(meta_provider.egg_info)
-    egg_name = pkg_resources.to_filename(dist.project_name)
-    return meta_provider.egg_info.endswith(egg_name + ".egg-info") \
-           and os.path.exists(os.path.join(egg_info_dir, "setup.py"))
-
-
-def left_trim_lines(lines):
-    # type: (List[str]) -> List[str]
-    """
-    Remove all unnecessary leading space from lines.
-    """
-    lines_striped = zip(lines[1:], map(str.lstrip, lines[1:]))
-    lines_striped = filter(itemgetter(1), lines_striped)
-    indent = min([len(line) - len(striped) \
-                  for line, striped in lines_striped] + [sys.maxsize])
-
-    if indent < sys.maxsize:
-        return [line[indent:] for line in lines]
-    else:
-        return list(lines)
-
-
-def trim_trailing_lines(lines):
-    # type: (List[str]) -> List[str]
-    """
-    Trim trailing blank lines.
-    """
-    lines = list(lines)
-    while lines and not lines[-1]:
-        lines.pop(-1)
-    return lines
-
-
-def trim_leading_lines(lines):
-    # type: (List[str]) -> List[str]
-    """
-    Trim leading blank lines.
-    """
-    lines = list(lines)
-    while lines and not lines[0]:
-        lines.pop(0)
-    return lines
-
-
-def trim(string):
-    # type: (str) -> str
-    """
-    Trim a string in PEP-256 compatible way
-    """
-    lines = string.expandtabs().splitlines()
-
-    lines = list(map(str.lstrip, lines[:1])) + left_trim_lines(lines[1:])
-
-    return "\n".join(trim_leading_lines(trim_trailing_lines(lines)))
-
-
-# Fields allowing multiple use (from PEP-0345)
-MULTIPLE_KEYS = ["Platform", "Supported-Platform", "Classifier",
-                 "Requires-Dist", "Provides-Dist", "Obsoletes-Dist",
-                 "Project-URL"]
-
-
-def parse_meta(contents):
-    # type: (str) -> Dict[str, Union[str, List[str]]]
-    message = email.message_from_string(contents)
-    meta = {}  # type: Dict[str, Union[str, List[str]]]
-    for key in set(message.keys()):
-        if key in MULTIPLE_KEYS:
-            meta[key] = list(str(m) for m in message.get_all(key))
-        else:
-            value = str(message.get(key))
-            if key == "Description":
-                value = trim(value)
-            meta[key] = value
-
-    version = StrictVersion(meta["Metadata-Version"])  # type: ignore
-
-    if version >= StrictVersion("1.3") and "Description" not in meta:
-        desc = message.get_payload()
-        if isinstance(desc, str):
-            meta["Description"] = desc
-    return meta
-
-
-def get_meta_entry(dist, name):
-    # type: (pkg_resources.Distribution, str) -> Union[List[str], str, None]
-    """
-    Get the contents of the named entry from the distributions PKG-INFO file
-    """
-    meta = get_dist_meta(dist)
-    return meta.get(name)
-
-
-def get_dist_url(dist):
-    # type: (pkg_resources.Distribution) -> Optional[str]
-    """
-    Return the 'url' of the distribution (as passed to setup function)
-    """
-    return get_meta_entry(dist, "Home-page")
-
-
-def get_dist_meta(dist):
-    # type: (pkg_resources.Distribution) -> Dict[str, Union[str, List[str]]]
-    contents = None  # type: Optional[str]
-    if dist.has_metadata("PKG-INFO"):
-        # egg-info
-        contents = dist.get_metadata("PKG-INFO")
-    elif dist.has_metadata("METADATA"):
-        # dist-info
-        contents = dist.get_metadata("METADATA")
-
-    if contents is not None:
-        return parse_meta(contents)
-    else:
-        return {}
 
 
 def _replacements_for_dist(dist):

--- a/orangecanvas/help/manager.py
+++ b/orangecanvas/help/manager.py
@@ -95,7 +95,6 @@ class HelpManager(QObject):
 
     def search(self, query):
         # type: (Union[QUrl, Dict[str, str], Sequence[Tuple[str, str]]]) -> QUrl
-
         if isinstance(query, QUrl):
             query = qurl_query_items(query)
 
@@ -109,6 +108,23 @@ class HelpManager(QObject):
 
         if provider is not None:
             return provider.search(desc)
+        else:
+            raise KeyError(desc_id)
+
+    async def search_async(self, query, timeout=2):
+        if isinstance(query, QUrl):
+            query = qurl_query_items(query)
+
+        query = dict(query)
+        desc_id = query["id"]
+        desc = self.description_by_id(desc_id)
+
+        provider = None
+        if desc.project_name:
+            provider = self.get_provider(desc.project_name)
+
+        if provider is not None:
+            return await provider.search_async(desc, timeout=timeout)
         else:
             raise KeyError(desc_id)
 

--- a/orangecanvas/utils/asyncutils.py
+++ b/orangecanvas/utils/asyncutils.py
@@ -1,0 +1,45 @@
+import os
+import asyncio
+from concurrent import futures
+
+from AnyQt.QtCore import QCoreApplication, QThread
+
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    """
+    Get the asyncio.AbstractEventLoop for the main Qt application thread.
+
+    The QCoreApplication instance must already have been created.
+    Must only be called from the main Qt application thread.
+    """
+    try:
+        # Python >= 3.7
+        get_running_loop = asyncio.get_running_loop
+    except AttributeError:
+        get_running_loop = asyncio._get_running_loop
+    app = QCoreApplication.instance()
+    if app is None:
+        raise RuntimeError("QCoreApplication is not running")
+    if app.thread() is not QThread.currentThread():
+        raise RuntimeError("Called from non-main thread")
+    try:
+        loop = get_running_loop()
+    except RuntimeError:
+        loop = None
+    else:
+        if loop is not None:
+            return loop
+
+    qt_api = os.environ.get("QT_API", "").lower()
+    if qt_api == "pyqt5":
+        os.environ["QT_API"] = "PyQt5"
+    elif qt_api == "pyside2":
+        os.environ["QT_API"] = "PySide2"
+    import qasync
+
+    if loop is None:
+        loop = qasync.QEventLoop(app)
+        # Do not use qasync.QEventLoop's default executor which uses QThread
+        # based pool and exhibits https://github.com/numpy/numpy/issues/11551
+        loop.set_default_executor(futures.ThreadPoolExecutor())
+    return loop

--- a/orangecanvas/utils/pkgmeta.py
+++ b/orangecanvas/utils/pkgmeta.py
@@ -1,0 +1,135 @@
+import os
+import sys
+import email
+from operator import itemgetter
+from distutils.version import StrictVersion
+
+from typing import TYPE_CHECKING, List, Dict, Optional, Union
+
+import pkg_resources
+
+if TYPE_CHECKING:
+    Distribution = pkg_resources.Distribution
+
+
+def is_develop_egg(dist):
+    # type: (Distribution) -> bool
+    """
+    Is the distribution installed in development mode (setup.py develop)
+    """
+    meta_provider = dist._provider
+    egg_info_dir = os.path.dirname(meta_provider.egg_info)
+    egg_name = pkg_resources.to_filename(dist.project_name)
+    return meta_provider.egg_info.endswith(egg_name + ".egg-info") \
+           and os.path.exists(os.path.join(egg_info_dir, "setup.py"))
+
+
+def left_trim_lines(lines):
+    # type: (List[str]) -> List[str]
+    """
+    Remove all unnecessary leading space from lines.
+    """
+    lines_striped = zip(lines[1:], map(str.lstrip, lines[1:]))
+    lines_striped = filter(itemgetter(1), lines_striped)
+    indent = min([len(line) - len(striped) \
+                  for line, striped in lines_striped] + [sys.maxsize])
+
+    if indent < sys.maxsize:
+        return [line[indent:] for line in lines]
+    else:
+        return list(lines)
+
+
+def trim_trailing_lines(lines):
+    # type: (List[str]) -> List[str]
+    """
+    Trim trailing blank lines.
+    """
+    lines = list(lines)
+    while lines and not lines[-1]:
+        lines.pop(-1)
+    return lines
+
+
+def trim_leading_lines(lines):
+    # type: (List[str]) -> List[str]
+    """
+    Trim leading blank lines.
+    """
+    lines = list(lines)
+    while lines and not lines[0]:
+        lines.pop(0)
+    return lines
+
+
+def trim(string):
+    # type: (str) -> str
+    """
+    Trim a string in PEP-256 compatible way
+    """
+    lines = string.expandtabs().splitlines()
+
+    lines = list(map(str.lstrip, lines[:1])) + left_trim_lines(lines[1:])
+
+    return "\n".join(trim_leading_lines(trim_trailing_lines(lines)))
+
+
+# Fields allowing multiple use (from PEP-0345)
+MULTIPLE_KEYS = ["Platform", "Supported-Platform", "Classifier",
+                 "Requires-Dist", "Provides-Dist", "Obsoletes-Dist",
+                 "Project-URL"]
+
+
+def parse_meta(contents):
+    # type: (str) -> Dict[str, Union[str, List[str]]]
+    message = email.message_from_string(contents)
+    meta = {}  # type: Dict[str, Union[str, List[str]]]
+    for key in set(message.keys()):
+        if key in MULTIPLE_KEYS:
+            meta[key] = list(str(m) for m in message.get_all(key))
+        else:
+            value = str(message.get(key))
+            if key == "Description":
+                value = trim(value)
+            meta[key] = value
+
+    version = StrictVersion(meta["Metadata-Version"])  # type: ignore
+
+    if version >= StrictVersion("1.3") and "Description" not in meta:
+        desc = message.get_payload()
+        if isinstance(desc, str):
+            meta["Description"] = desc
+    return meta
+
+
+def get_meta_entry(dist, name):
+    # type: (pkg_resources.Distribution, str) -> Union[List[str], str, None]
+    """
+    Get the contents of the named entry from the distributions PKG-INFO file
+    """
+    meta = get_dist_meta(dist)
+    return meta.get(name)
+
+
+def get_dist_url(dist):
+    # type: (pkg_resources.Distribution) -> Optional[str]
+    """
+    Return the 'url' of the distribution (as passed to setup function)
+    """
+    return get_meta_entry(dist, "Home-page")
+
+
+def get_dist_meta(dist):
+    # type: (pkg_resources.Distribution) -> Dict[str, Union[str, List[str]]]
+    contents = None  # type: Optional[str]
+    if dist.has_metadata("PKG-INFO"):
+        # egg-info
+        contents = dist.get_metadata("PKG-INFO")
+    elif dist.has_metadata("METADATA"):
+        # dist-info
+        contents = dist.get_metadata("METADATA")
+
+    if contents is not None:
+        return parse_meta(contents)
+    else:
+        return {}

--- a/orangecanvas/utils/qobjref.py
+++ b/orangecanvas/utils/qobjref.py
@@ -1,0 +1,178 @@
+import weakref
+from types import SimpleNamespace as namespace
+from typing import Optional, TypeVar, Generic
+
+from AnyQt.QtCore import QObject, Qt
+
+__all__ = [
+    "qobjref", "qobjref_weak"
+]
+
+Q = TypeVar("Q", bound=QObject)
+
+
+class qobjref(Generic[Q]):
+    """
+    A 'guarded reference' to a QObject.
+
+    An instance of a `qobjref` holds a reference to a `QObject` for as long
+    as it is alive (not destroyed by C++ destructor).
+
+    Example
+    -------
+    >>> import sip
+    >>> obj = QObject()
+    >>> ref = qobjref(obj)
+    >>> assert ref() is obj
+    >>> sip.delete(obj)  # forcibly delete it
+    >>> assert ref() is None
+
+    Note
+    ----
+    This is not thread safe in the sense that the object can be deleted
+    from a different thread while the ref() is returning it.
+
+    Note
+    ----
+    `qobjref` keeps a reference to the object, meaning it will not be
+    garbage collected until qobjref is also reaped. Use qobjref_weak
+    for weak references.
+
+    See also
+    --------
+    QPointer
+    """
+    __slots__ = ("__obj", "__state", "__weakref__")
+
+    def __init__(self, obj):
+        # type: (Q) -> None
+        assert isinstance(obj, QObject)
+        self.__obj = obj
+
+        def finalize(_weakref):
+            # finalize when self is collected
+            if state.objref is None:
+                return
+            objref = state.objref()
+            if objref is not None:
+                objref.destroyed.disconnect(state.zero_ref)
+
+        # destroy/zero the reference when QObject is destroyed
+        def zero_ref():
+            selfref = state.selfref()
+            if selfref is not None:
+                selfref.__obj = None
+            state.objref = None
+
+        state = namespace(
+            selfref=weakref.ref(self, finalize),
+            objref=weakref.ref(obj),
+            zero_ref=zero_ref,
+            finalize=finalize)
+        self.__state = state
+
+        # Must not capture self in the zero_ref's closure
+        obj.destroyed.connect(zero_ref, Qt.DirectConnection)
+
+    def __call__(self):
+        # type: () -> Optional[Q]
+        """
+        Return the QObject instance or None if it was destroyed.
+
+        Return
+        ------
+        obj : Optional[QObject]
+        """
+        return self.__obj
+
+    def __repr__(self):
+        objrep = "to " + repr(self.__obj)
+        if self.__obj is None:
+            objrep = "dead"
+
+        return "<qobjref at 0x%x; " % id(self) + objrep + ">"
+
+
+class qobjref_weak(Generic[Q]):
+    """
+    A weak 'guarded reference' to a QObject.
+
+    Similar to `qobjref`, except that the reference to the QObject is weak
+
+    Example
+    -------
+    >>> import sip
+    >>> obj = QObject()
+    >>> ref = qobjref_weak(obj)
+    >>> assert ref() is obj
+    >>> sip.delete(obj)  # forcibly delete it
+    >>> assert ref() is None
+    >>> obj = QObject()
+    >>> ref = qobjref_weak(obj)
+    >>> assert ref() is obj
+    >>> del obj  # assuming ref count is 1
+    >>> assert ref() is None
+
+    Note
+    ----
+    This is not thread safe in the sense that the object can be
+    deleted from a different thread while the ref() is returning it.
+
+    See also
+    --------
+    qobjref, QPointer
+    """
+    __slots__ = ("__obj_ref", "__state", "__weakref__")
+
+    def __init__(self, obj):
+        # type: (Q) -> None
+        assert isinstance(obj, QObject)
+        self.__obj_ref = weakref.ref(obj)
+
+        # finalize when self is collected
+        def disconnect(_weakref):
+            if state.objref is None:
+                return
+            objref = state.objref()
+            if objref is not None:
+                objref.destroyed.disconnect(state.zero_ref)
+
+        # destroy/zero the reference when QObject is destroyed
+        def zero_ref():
+            selfref = state.selfref()
+            if selfref is not None:
+                selfref.__obj_ref = None
+            state.objref = None
+
+        state = namespace(
+            selfref=weakref.ref(self, disconnect),
+            objref=weakref.ref(obj),
+            zero_ref=zero_ref,
+            disconnect=disconnect)
+        self.__state = state
+
+        # Must not capture self in the zero_ref's closure
+        obj.destroyed.connect(zero_ref, Qt.DirectConnection)
+
+    def __call__(self):
+        # type: () -> Optional[Q]
+        """
+        Return the QObject instance or None if it is no longer alive
+
+        Return
+        ------
+        obj : Optional[QObject]
+        """
+        ref = self.__obj_ref
+        if ref is not None:
+            return ref()
+        else:
+            return None
+
+    def __repr__(self):
+        obj = self.__call__()
+        if obj is not None:
+            objrep = "to " + repr(obj)
+        else:
+            objrep = "dead"
+        return "<qobjref_weak at 0x%x; " % id(self) + objrep + ">"

--- a/orangecanvas/utils/tests/test_qobjref.py
+++ b/orangecanvas/utils/tests/test_qobjref.py
@@ -1,0 +1,69 @@
+import weakref
+
+from AnyQt.QtCore import QObject, QCoreApplication, QEvent
+
+from ...gui.test import QCoreAppTestCase
+from ..qobjref import qobjref, qobjref_weak
+
+
+def delete_qobject(obj):
+    obj.deleteLater()
+    QCoreApplication.sendPostedEvents(obj, QEvent.DeferredDelete)
+
+
+class TestQObjectRef(QCoreAppTestCase):
+    def test_delete(self):
+        obj = QObject()
+        ref = qobjref(obj)
+        assert ref() is obj
+        delete_qobject(obj)  # forcibly delete it
+        assert ref() is None
+
+    def test_deref(self):
+        obj = QObject()
+        obj_wref = weakref.ref(obj)
+        ref = qobjref(obj)
+        del obj
+        assert ref() is obj_wref()
+        del ref
+        assert obj_wref() is None
+
+    def test_self_finalize(self):
+        obj = QObject()
+        ref = qobjref(obj)
+        del ref
+
+    def test_repr(self):
+        obj = QObject()
+        ref = qobjref(obj)
+        assert " to " in repr(ref)
+        delete_qobject(obj)
+        assert "dead" in repr(ref)
+
+
+class TestQObjectWeakRef(QCoreAppTestCase):
+    def test_delete(self):
+        obj = QObject()
+        ref = qobjref_weak(obj)
+        assert ref() is obj
+        delete_qobject(obj)  # forcibly delete it
+        assert ref() is None
+
+    def test_deref(self):
+        obj = QObject()
+        ref = qobjref_weak(obj)
+        obj_wref = weakref.ref(obj)
+        del obj
+        assert ref() is obj_wref() is None
+
+    def test_self_finalize(self):
+        obj = QObject()
+        ref = qobjref_weak(obj)
+        del ref
+
+    def test_repr(self):
+        obj = QObject()
+        ref = qobjref_weak(obj)
+        assert " to " in repr(ref)
+        delete_qobject(obj)
+        assert "dead" in repr(ref)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ INSTALL_REQUIRES = (
     "requests",
     "cachecontrol[filecache]",
     "pip>=18.0",
-    "dictdiffer"
+    "dictdiffer",
+    "qasync",
 )
 
 


### PR DESCRIPTION
### Issue

Currently the help system hits the network as soon as it is created (if any registered help entry point does not have locally installed help files) i.e. at main window creation time.

### Changes

Initialize the help providers only when help is requested. Run the query as async task.


