### PR TITLE
[FIX] widgetmanager: Fix widget creation with OnDemand policy

### DIFF
--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -555,7 +555,7 @@ class WidgetManager(QObject):
 
     def eventFilter(self, recv, event):
         # type: (QObject, QEvent) -> bool
-        if isinstance(recv, SchemeNode) and recv in self.__item_for_node:
+        if isinstance(recv, SchemeNode):
             if event.type() == NodeEvent.NodeActivateRequest:
                 self.__activate_widget_for_node(recv)
             self.__dispatch_events(recv, event)


### PR DESCRIPTION
### Issue

Since gh-118 widget manager does not create widgets on double click if in OnDemand creation mode (e.g. if 'freeze' action is toogled on in canvas). 

### Changes

Remove an erroneous check.

