### PR TITLE
Raise AnyQt to 0.0.11 to fix mouse wheel scrolling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ PACKAGE_DATA = {
 
 INSTALL_REQUIRES = (
     "setuptools",
-    "AnyQt",
+    "AnyQt>=0.0.11",
     "docutils",
     "commonmark>=0.8.1",
     "requests",


### PR DESCRIPTION
Mouse wheel scrolling was crashing for PyQt < 5.12.