### PR TITLE
Restart + Small style changes for Add-ons dialogue

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1293,7 +1293,7 @@ def list_available_versions(config, session=None):
         distributions.append(response.json())
 
     packages = []
-    for addon in defaults + distributions:
+    for addon in distributions + defaults:
         try:
             packages.append(installable_from_json_response(addon))
         except (TypeError, KeyError):

--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1131,7 +1131,7 @@ class AddonManagerDialog(QDialog):
 
         if QMessageBox.Ok == message_restart(self):
             self.accept()
-            QTimer.singleShot(0, QApplication.closeAllWindows)
+            QApplication.closeAllWindows()
             QTimer.singleShot(0, QApplication.quit)
         else:
             self.reject()

--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1114,25 +1114,41 @@ class AddonManagerDialog(QDialog):
 
     def __on_installer_finished(self):
         self.__on_installer_finished_common()
+        name = QApplication.applicationName() or 'Orange'
 
         def message_restart(parent):
             icon = QMessageBox.Information
             buttons = QMessageBox.Ok | QMessageBox.Cancel
             title = 'Information'
-            name = QApplication.applicationName() or 'Orange'
             text = ('{} needs to be restarted for the changes to take effect.'
                     .format(name))
             msg_box = QMessageBox(icon, title, text, buttons, parent)
             msg_box.setDefaultButton(QMessageBox.Ok)
-            msg_box.setInformativeText('Press OK to close {} now.'
+            msg_box.setInformativeText('Press OK to restart {} now.'
                                        .format(name))
             msg_box.button(QMessageBox.Cancel).setText('Close later')
             return msg_box.exec_()
 
         if QMessageBox.Ok == message_restart(self):
             self.accept()
-            QApplication.closeAllWindows()
-            QTimer.singleShot(0, lambda: QApplication.exit(96))
+
+            def restart():
+                quit_temp_val = QApplication.quitOnLastWindowClosed()
+                QApplication.setQuitOnLastWindowClosed(False)
+                QApplication.closeAllWindows()
+                windows = QApplication.topLevelWindows()
+                if any(w.isVisible() for w in windows):  # if a window close was cancelled
+                    QApplication.setQuitOnLastWindowClosed(quit_temp_val)
+                    QMessageBox(
+                        text="Restart Cancelled",
+                        informativeText="Changes will be applied on {}'s next restart"
+                                        .format(name),
+                        icon=QMessageBox.Information
+                    ).exec()
+                else:
+                    QApplication.exit(96)
+
+            QTimer.singleShot(0, restart)
         else:
             self.reject()
 

--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1132,7 +1132,7 @@ class AddonManagerDialog(QDialog):
         if QMessageBox.Ok == message_restart(self):
             self.accept()
             QApplication.closeAllWindows()
-            QTimer.singleShot(0, QApplication.quit)
+            QTimer.singleShot(0, lambda: QApplication.exit(96))
         else:
             self.reject()
 

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -2061,7 +2061,7 @@ class CanvasMainWindow(QMainWindow):
                         .format(name=name),
                         parent=self).exec_()
         dlg = addons.AddonManagerDialog(
-            self, windowTitle=self.tr("Add-ons"), modal=True
+            self, windowTitle=self.tr("Installer"), modal=True
         )
         dlg.setStyle(QApplication.style())
         dlg.setAttribute(Qt.WA_DeleteOnClose)

--- a/orangecanvas/application/tests/test_application.py
+++ b/orangecanvas/application/tests/test_application.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import time
+import unittest
+
+from orangecanvas.utils import shtools as sh
+from orangecanvas.application import application as appmod
+from orangecanvas.utils.shtools import temp_named_file
+
+
+def application_test_helper():
+    app = appmod.CanvasApplication([])
+    app.quit()
+    return
+
+
+class TestApplication(unittest.TestCase):
+    def test_application(self):
+        res = sh.python_run([
+            "-c",
+            f"import {__name__} as m\n"
+            f"m.application_test_helper()\n"
+        ])
+        self.assertEqual(res.returncode, 0)
+
+
+def remove_after_exit(fname):
+    appmod.run_after_exit([
+        sys.executable, '-c', f'import os, sys; os.remove(sys.argv[1])', fname
+    ])
+
+
+def restart_command_test_helper(fname):
+    cmd = [
+        sys.executable, '-c', f'import os, sys; os.remove(sys.argv[1])', fname
+    ]
+    appmod.set_restart_command(cmd)
+    assert appmod.restart_command() == cmd
+    appmod.restart_cancel()
+    assert appmod.restart_command() is None
+    appmod.set_restart_command(cmd)
+
+
+class TestApplicationRestart(unittest.TestCase):
+    def test_restart_command(self):
+        with temp_named_file('', delete=False) as fname:
+            res = sh.python_run([
+                "-c",
+                f"import sys, {__name__} as m\n"
+                f"m.restart_command_test_helper(sys.argv[1])\n",
+                fname
+            ])
+            start = time.perf_counter()
+            while os.path.exists(fname) and time.perf_counter() - start < 5:
+                pass
+            self.assertFalse(os.path.exists(fname))
+            self.assertEqual(res.returncode, 0)

--- a/orangecanvas/main.py
+++ b/orangecanvas/main.py
@@ -21,6 +21,7 @@ import pkg_resources
 from AnyQt.QtGui import QFont, QColor, QPalette
 from AnyQt.QtCore import Qt, QDir, QSettings, QT_VERSION
 
+from .utils.after_exit import run_after_exit
 from .styles import breeze_dark
 from .application.application import CanvasApplication
 from .application.canvasmain import CanvasMainWindow
@@ -435,6 +436,11 @@ def main(argv=None):
     gc.collect()
 
     del app
+
+    if status == 96:
+        log.info('Restarting via exit code 96.')
+        run_after_exit([sys.executable, sys.argv[0]])
+
     return status
 
 

--- a/orangecanvas/utils/after_exit.py
+++ b/orangecanvas/utils/after_exit.py
@@ -1,0 +1,74 @@
+import argparse
+import logging
+import os
+import sys
+import subprocess
+
+from typing import Sequence, Optional
+
+import orangecanvas.utils.shtools as sh
+
+
+def run_after_exit(
+        command: Sequence[str] = (), log: Optional[str] = None
+) -> None:
+    """
+    Run the `command` after this process exits.
+    """
+    # pass read end of a pipe to subprocess. It blocks to read from it
+    # and will not succeed until the write end is closed which will happen at
+    # this process's exit (assuming `w` is not leaked in a fork).
+    command = ["--arg=" + c for c in command]
+    if log is not None:
+        command.append("--log=" + log)
+    command = ["-m", __name__, *command]
+    r, w = os.pipe()
+    p = sh.python_process(
+        command,
+        stdin=r, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    # close the read end of the pipe
+    os.close(r)
+    # Popen warns in __del__ if child did not complete yet (should
+    # double fork to do this right, but since we exit immediately anyways).
+    run_after_exit.processes.append(p)
+
+
+run_after_exit.processes = []
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-f", default=0, type=int)
+    ap.add_argument("-a", "--arg", action='append', default=[])
+    ap.add_argument("--log", help="Log file", type=argparse.FileType("w"))
+    ns, rest = ap.parse_known_args(argv)
+
+    if ns.log is not None:
+        logging.basicConfig(level=logging.INFO, stream=ns.log)
+    log = logging.getLogger(__name__)
+
+    if ns.f is not None:
+        readfd = int(ns.f)
+    else:
+        readfd = 0
+
+    # read form readfd (an os.pipe read end) until EOF indicating parent
+    # closed the pipe (i.e. did exit)
+    log.info("Blocking on read from fd: %d", readfd)
+    c = os.read(readfd, 1)
+    if c != b"":
+        log.error("Unexpected content %r from parent", c)
+    else:
+        log.info("Parent closed fd; %d")
+
+    if ns.arg:
+        log.info("Starting new process with cmd: %r", ns.arg)
+        kwargs = {}
+        p = sh.create_process(ns.arg, **kwargs)
+        main.p = p
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/orangecanvas/utils/shtools.py
+++ b/orangecanvas/utils/shtools.py
@@ -109,6 +109,7 @@ def temp_named_file(
         suffix: Optional[str] = None,
         prefix: Optional[str] = None,
         dir: Optional[str] = None,
+        delete=True,
 ) -> Generator[str, None, None]:
     """
     Create a named temporary file initialized with `contents` and yield
@@ -126,11 +127,13 @@ def temp_named_file(
         Filename prefix
     dir: Optional[str]
         Directory where the file will be created. If None then $TEMP is used.
+    delete: bool
+        If true the file will be deleted on context exit.
 
     Returns
     -------
     context: ContextManager
-        A context manager that deletes the file on exit.
+        A context manager that deletes the file on exit (if delete is True).
 
     See Also
     --------
@@ -143,4 +146,5 @@ def temp_named_file(
     try:
         yield name
     finally:
-        os.remove(name)
+        if delete:
+            os.remove(name)

--- a/orangecanvas/utils/tests/test_after_exit.py
+++ b/orangecanvas/utils/tests/test_after_exit.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import time
+import unittest
+
+import orangecanvas.utils.after_exit as ae
+import orangecanvas.utils.shtools as sh
+
+
+def remove_after_exit(fname):
+    ae.run_after_exit([
+        sys.executable, '-c', f'import os, sys; os.remove(sys.argv[1])', fname
+    ])
+
+
+class TestAfterExit(unittest.TestCase):
+    def test_after_exit(self):
+        with sh.temp_named_file('', delete=False) as fname:
+            r = sh.python_run([
+                "-c",
+                f"import sys, {__name__} as m\n"
+                f"m.remove_after_exit(sys.argv[1])",
+                fname
+            ])
+
+            start = time.perf_counter()
+            while os.path.exists(fname) and time.perf_counter() - start < 5:
+                pass
+            self.assertEqual(r.returncode, 0)
+            self.assertFalse(os.path.exists(fname))


### PR DESCRIPTION
This PR and https://github.com/biolab/orange3/pull/5064, are separate (do not depend on each other), but when both of them are used together, Orange will restart upon installing an addon, instead of just closing.

The main package is moved to the top of the list, and the Add-ons window is renamed.

Also, question @ales-erjavec, why is `QTimer.singleShot` used to invoke QApplication methods? 49e8fb9 changes the first call, because otherwise exit is invoked before the user has a chance to go through the windows' "Do you wish to save?" dialogues. Does this break anything?