### PR TITLE
[ENH] Visible channels on widget anchors

### DIFF
--- a/orangecanvas/canvas/items/linkitem.py
+++ b/orangecanvas/canvas/items/linkitem.py
@@ -375,8 +375,8 @@ class LinkItem(QGraphicsWidget):
         self.__updatePalette()
         self.__updateFont()
 
-    def setSourceItem(self, item, anchor=None):
-        # type: (Optional[NodeItem], Optional[AnchorPoint]) -> None
+    def setSourceItem(self, item, signal=None, anchor=None):
+        # type: (Optional[NodeItem], Optional[InputSignal], Optional[AnchorPoint]) -> None
         """
         Set the source `item` (:class:`.NodeItem`). Use `anchor`
         (:class:`.AnchorPoint`) as the curve start point (if ``None`` a new
@@ -406,7 +406,7 @@ class LinkItem(QGraphicsWidget):
 
             if item is not None and anchor is None:
                 # Create a new output anchor for the item if none is provided.
-                anchor = item.newOutputAnchor()
+                anchor = item.newOutputAnchor(signal)
             if item is not None:
                 item.selectedChanged.connect(self.__updateSelectedState)
 
@@ -425,8 +425,8 @@ class LinkItem(QGraphicsWidget):
 
         self.__updateCurve()
 
-    def setSinkItem(self, item, anchor=None):
-        # type: (Optional[NodeItem], Optional[AnchorPoint]) -> None
+    def setSinkItem(self, item, signal=None, anchor=None):
+        # type: (Optional[NodeItem], Optional[InputSignal], Optional[AnchorPoint]) -> None
         """
         Set the sink `item` (:class:`.NodeItem`). Use `anchor`
         (:class:`.AnchorPoint`) as the curve end point (if ``None`` a new
@@ -456,7 +456,7 @@ class LinkItem(QGraphicsWidget):
 
             if item is not None and anchor is None:
                 # Create a new input anchor for the item if none is provided.
-                anchor = item.newInputAnchor()
+                anchor = item.newInputAnchor(signal)
             if item is not None:
                 item.selectedChanged.connect(self.__updateSelectedState)
 

--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -927,18 +927,21 @@ class NodeAnchorItem(GraphicsPathObject):
         else:
             return GraphicsPathObject.boundingRect(self)
 
-    def hoverEnterEvent(self, event):
-        self.__hover = True
-        brush = self.connectedHoverBrush if self.anchored else self.normalHoverBrush
+    def setHovered(self, enabled):
+        self.__hover = enabled
+        if enabled:
+            brush = self.connectedHoverBrush if self.anchored else self.normalHoverBrush
+        else:
+            brush = self.connectedBrush if self.anchored else self.normalBrush
         self.setBrush(brush)
         self.__updateHoverState()
+
+    def hoverEnterEvent(self, event):
+        self.setHovered(True)
         return super().hoverEnterEvent(event)
 
     def hoverLeaveEvent(self, event):
-        self.__hover = False
-        brush = self.connectedBrush if self.anchored else self.normalBrush
-        self.setBrush(brush)
-        self.__updateHoverState()
+        self.setHovered(False)
         return super().hoverLeaveEvent(event)
 
     def setAnimationEnabled(self, enabled):
@@ -963,6 +966,7 @@ class NodeAnchorItem(GraphicsPathObject):
 
     def __updateHoverState(self):
         self.__updateShadowState()
+        self.__updatePositions()
 
         for indicator in self.anchorPoints():
             indicator.setHoverState(self.__hover)

--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -605,6 +605,7 @@ class NodeAnchorItem(GraphicsPathObject):
         self.__animationEnabled = False
         self.__hover = False
         self.__anchorOpen = False
+        self.__keepAnchorOpen = False
 
         # Does this item have any anchored links.
         self.anchored = False
@@ -661,6 +662,11 @@ class NodeAnchorItem(GraphicsPathObject):
     def setSignals(self, signals):
         self.__signals = signals
         self.setAnchorPath(self.__anchorPath)
+
+    def setKeepAnchorOpen(self, enabled):
+        if self.__keepAnchorOpen != enabled:
+            self.__keepAnchorOpen = enabled
+            self.__updatePositions()
 
     def parentNodeItem(self):
         # type: () -> Optional['NodeItem']
@@ -1020,7 +1026,7 @@ class NodeAnchorItem(GraphicsPathObject):
         # type: () -> None
         """Update anchor points positions.
         """
-        if self.__anchorOpen and self.__hover:
+        if self.__keepAnchorOpen or self.__anchorOpen and self.__hover:
             dashPattern = self.__channelDash
             stroke = self.__channelStroke
             targetPoss = self.__channelPointPositions
@@ -1035,7 +1041,7 @@ class NodeAnchorItem(GraphicsPathObject):
 
         if self.animGroup.state() == QPropertyAnimation.Running:
             self.animGroup.stop()
-        if self.__animationEnabled and animate:
+        if self.__animationEnabled:
             self.__initializeAnimation(targetPoss, dashPattern)
             self.animGroup.start()
         else:

--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -7,7 +7,6 @@ Node Item
 import math
 import typing
 import string
-import numpy as np
 
 from operator import attrgetter
 from itertools import groupby
@@ -31,7 +30,6 @@ from AnyQt.QtCore import (
     QParallelAnimationGroup)
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 from PyQt5.QtCore import pyqtProperty
-from scipy.interpolate import interp1d
 
 from .graphicspathobject import GraphicsPathObject
 from .graphicstextitem import GraphicsTextItem
@@ -43,6 +41,7 @@ from ...registry import NAMED_COLORS, WidgetDescription, CategoryDescription, \
 from ...resources import icon_loader
 from .utils import uniform_linear_layout_trunc
 from ...utils import set_flag
+from ...utils.mathutils import interp1d
 
 if typing.TYPE_CHECKING:
     from ...registry import WidgetDescription
@@ -739,9 +738,9 @@ class NodeAnchorItem(GraphicsPathObject):
         fullAnchor = drawDashPattern(1)
         dash6, channelAnchor = matchDashPattern(dash6, channelAnchor)
         channelAnchor, fullAnchor = matchDashPattern(channelAnchor, fullAnchor)
-        self.__unanchoredDash = np.array(dash6)
-        self.__channelDash = np.array(channelAnchor)
-        self.__anchoredDash = np.array(fullAnchor)
+        self.__unanchoredDash = dash6
+        self.__channelDash = channelAnchor
+        self.__anchoredDash = fullAnchor
 
         # The full stroke
         stroke_path.setDashPattern(fullAnchor)
@@ -1067,8 +1066,8 @@ class NodeAnchorItem(GraphicsPathObject):
             lblAnim.setStartValue(lbl.opacity())
             lblAnim.setEndValue(1 if sig in showSignals else 0)
 
-        startDash = np.array(self.__pathStroker.dashPattern())
-        self.__interpDash = interp1d([0, 1], np.vstack([startDash, endDash]), axis=0)
+        startDash = self.__pathStroker.dashPattern()
+        self.__interpDash = interp1d(startDash, endDash)
         self.__anchorPathAnim.setStartValue(0)
         self.__anchorPathAnim.setEndValue(1)
 

--- a/orangecanvas/canvas/items/tests/test_linkitem.py
+++ b/orangecanvas/canvas/items/tests/test_linkitem.py
@@ -50,19 +50,19 @@ class TestLinkItem(TestItems):
         self.assertSequenceEqual(one_item.outputAnchors(), [anchor1])
         self.assertSequenceEqual(negate_item.inputAnchors(), [anchor2])
 
-        link.setSourceItem(one_item, anchor1)
-        link.setSinkItem(negate_item, anchor2)
+        link.setSourceItem(one_item, anchor=anchor1)
+        link.setSinkItem(negate_item, anchor=anchor2)
 
         # Setting an item and an anchor not in the item's anchors raises
         # an error.
         with self.assertRaises(ValueError):
-            link.setSourceItem(one_item, AnchorPoint())
+            link.setSourceItem(one_item, anchor=AnchorPoint())
 
         self.assertSequenceEqual(one_item.outputAnchors(), [anchor1])
 
         anchor2 = one_item.newOutputAnchor()
 
-        link.setSourceItem(one_item, anchor2)
+        link.setSourceItem(one_item, anchor=anchor2)
         self.assertSequenceEqual(one_item.outputAnchors(), [anchor1, anchor2])
         self.assertIs(link.sourceAnchor, anchor2)
 
@@ -99,8 +99,8 @@ class TestLinkItem(TestItems):
         self.scene.addItem(anchor1)
         self.scene.addItem(anchor2)
 
-        link.setSourceItem(None, anchor1)
-        link.setSinkItem(None, anchor2)
+        link.setSourceItem(None, anchor=anchor1)
+        link.setSinkItem(None, anchor=anchor2)
 
         anchor2.setPos(100, 100)
 

--- a/orangecanvas/canvas/items/tests/test_nodeitem.py
+++ b/orangecanvas/canvas/items/tests/test_nodeitem.py
@@ -159,9 +159,9 @@ class TestNodeItem(TestItems):
 
         self.assertSequenceEqual(anchoritem.anchorPoints(), [anchor, anchor1])
 
-        self.assertSequenceEqual(anchoritem.anchorPositions(), [0.5, 0.5])
-        anchoritem.setAnchorPositions([0.5, 0.0])
+        self.assertSequenceEqual(anchoritem.anchorPositions(), [2/3, 1/3])
 
+        anchoritem.setAnchorPositions([0.5, 0.0])
         self.assertSequenceEqual(anchoritem.anchorPositions(), [0.5, 0.0])
 
         def advance():

--- a/orangecanvas/canvas/items/tests/test_nodeitem.py
+++ b/orangecanvas/canvas/items/tests/test_nodeitem.py
@@ -5,6 +5,7 @@ from AnyQt.QtGui import QPainterPath
 from .. import NodeItem, AnchorPoint, NodeAnchorItem
 
 from . import TestItems
+from ....registry import InputSignal
 from ....registry.tests import small_testing_registry
 
 
@@ -132,6 +133,7 @@ class TestNodeItem(TestItems):
 
     def test_anchoritem(self):
         anchoritem = NodeAnchorItem(None)
+        anchoritem.setAnimationEnabled(False)
         self.scene.addItem(anchoritem)
 
         path = QPainterPath()
@@ -175,3 +177,31 @@ class TestNodeItem(TestItems):
 
         self.qWait()
         timer.stop()
+
+        anchoritem.setAnchorOpen(True)
+        anchoritem.setHovered(True)
+        self.assertEqual(*[
+            p.scenePos() for p in anchoritem.anchorPoints()
+        ])
+        anchoritem.setAnchorOpen(False)
+        self.assertNotEqual(*[
+            p.scenePos() for p in anchoritem.anchorPoints()
+        ])
+        anchoritem.setAnchorOpen(False)
+        anchoritem.setHovered(True)
+        self.assertNotEqual(*[
+            p.scenePos() for p in anchoritem.anchorPoints()
+        ])
+
+        anchoritem = NodeAnchorItem(None)
+
+        anchoritem.setSignals([
+            InputSignal("first", "object", "set_first"),
+            InputSignal("second", "object", "set_second")
+        ])
+        self.assertListEqual(anchoritem._NodeAnchorItem__pathStroker.dashPattern(),
+                             list(anchoritem._NodeAnchorItem__unanchoredDash))
+        anchoritem.setAnchorOpen(True)
+        anchoritem.setHovered(True)
+        self.assertListEqual(anchoritem._NodeAnchorItem__pathStroker.dashPattern(),
+                             list(anchoritem._NodeAnchorItem__channelDash))

--- a/orangecanvas/canvas/scene.py
+++ b/orangecanvas/canvas/scene.py
@@ -484,8 +484,8 @@ class CanvasScene(QGraphicsScene):
         Construct and return a new :class:`.LinkItem`
         """
         item = items.LinkItem()
-        item.setSourceItem(source_item)
-        item.setSinkItem(sink_item)
+        item.setSourceItem(source_item, source_channel)
+        item.setSinkItem(sink_item, sink_channel)
 
         def channel_name(channel):
             # type: (Union[OutputSignal, InputSignal, str]) -> str

--- a/orangecanvas/canvas/scene.py
+++ b/orangecanvas/canvas/scene.py
@@ -18,7 +18,7 @@ from AnyQt.QtWidgets import QGraphicsScene, QGraphicsItem
 from AnyQt.QtGui import QPainter, QColor, QFont
 from AnyQt.QtCore import (
     Qt, QPointF, QRectF, QSizeF, QLineF, QBuffer, QObject, QSignalMapper,
-    QT_VERSION
+    QParallelAnimationGroup, QT_VERSION
 )
 from AnyQt.QtSvg import QSvgGenerator
 from AnyQt.QtCore import pyqtSignal as Signal
@@ -140,6 +140,8 @@ class CanvasScene(QGraphicsScene):
         self.link_activated_mapper.mapped[QObject].connect(
             lambda node: self.link_item_activated.emit(node)
         )
+
+        self.__anchors_opened = False
 
     def clear_scene(self):  # type: () -> None
         """
@@ -385,6 +387,8 @@ class CanvasScene(QGraphicsScene):
         """
         Remove `item` (:class:`.NodeItem`) from the scene.
         """
+        desc = item.widget_description
+
         self.activated_mapper.removeMappings(item)
         self.hovered_mapper.removeMappings(item)
         self.position_change_mapper.removeMappings(item)
@@ -755,6 +759,15 @@ class CanvasScene(QGraphicsScene):
         neighbors.extend(map(attrgetter("sinkItem"),
                              self.node_output_links(node_item)))
         return neighbors
+
+    def set_widget_anchors_open(self, enabled):
+        if self.__anchors_opened == enabled:
+            return
+        self.__anchors_opened = enabled
+
+        for item in self.node_items():
+            item.inputAnchorItem.setAnchorOpen(enabled)
+            item.outputAnchorItem.setAnchorOpen(enabled)
 
     def _on_position_change(self, item):
         # type: (NodeItem) -> None

--- a/orangecanvas/canvas/tests/test_scene.py
+++ b/orangecanvas/canvas/tests/test_scene.py
@@ -53,11 +53,16 @@ class TestScene(QAppTestCase):
         with self.assertRaises(ValueError):
             self.scene.add_node_item(cons_item)
 
+        a1 = one_desc.outputs[0]
+        a2 = negate_desc.inputs[0]
+        a3 = negate_desc.outputs[0]
+        a4 = cons_desc.inputs[0]
+
         # Add links
         link1 = self.scene.new_link_item(
-            one_item, "value", negate_item, "value")
+            one_item, a1, negate_item, a2)
         link2 = self.scene.new_link_item(
-            negate_item, "result", cons_item, "first")
+            negate_item, a3, cons_item, a4)
 
         link1a = self.scene.add_link_item(link1)
         link2a = self.scene.add_link_item(link2)
@@ -80,7 +85,7 @@ class TestScene(QAppTestCase):
 
         # And add one link again
         link1 = self.scene.new_link_item(
-            one_item, "value", negate_item, "value")
+            one_item, a1, negate_item, a2)
         link1 = self.scene.add_link_item(link1)
         self.assertSequenceEqual(self.scene.link_items(), [link1])
 

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -579,13 +579,16 @@ class NewLinkAction(UserInteraction):
         pos = event.screenPos()
         menu = self.document.quickMenu()
         node = self.scene.node_for_item(self.from_item)
+        from_signal = self.from_signal
         from_desc = node.description
 
-        def is_compatible(source, sink):
+        def is_compatible(source_signal, source, sink, sink_signal):
             # type: (WidgetDescription, WidgetDescription) -> bool
             return any(scheme.compatible_channels(output, input)
-                       for output in source.outputs
-                       for input in sink.inputs)
+                       for output
+                       in ([source_signal] if source_signal else source.outputs)
+                       for input
+                       in ([sink_signal] if sink_signal else sink.inputs))
 
         from_sink = self.direction == self.FROM_SINK
         if from_sink:
@@ -604,7 +607,7 @@ class NewLinkAction(UserInteraction):
         def filter(index):
             desc = index.data(QtWidgetRegistry.WIDGET_DESC_ROLE)
             if isinstance(desc, WidgetDescription):
-                return is_compatible(from_desc, desc)
+                return is_compatible(from_signal, from_desc, desc, None)
             else:
                 return False
 

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -441,6 +441,7 @@ class NewLinkAction(UserInteraction):
 
             if anchor.anchorOpen():
                 signal = anchor.signalAtPos(scenePos)
+                anchor.setKeepAnchorOpen(True)
             else:
                 signal = None
             self.from_signal = signal
@@ -800,6 +801,11 @@ class NewLinkAction(UserInteraction):
         """
         Cleanup all temporary items in the scene that are left.
         """
+        if self.from_item:
+            if self.direction == self.FROM_SOURCE:
+                self.from_item.outputAnchorItem.setKeepAnchorOpen(False)
+            else:
+                self.from_item.inputAnchorItem.setKeepAnchorOpen(False)
         if self.tmp_link_item:
             self.tmp_link_item.setSinkItem(None)
             self.tmp_link_item.setSourceItem(None)

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -269,7 +269,6 @@ class NewLinkAction(UserInteraction):
         super().__init__(document, *args, **kwargs)
         self.from_item = None    # type: Optional[items.NodeItem]
         self.direction = 0   # type: int
-        self.force_link_dialog = False
 
         # An `NodeItem` currently under the mouse as a possible
         # link drop target.
@@ -452,7 +451,6 @@ class NewLinkAction(UserInteraction):
     def mouseReleaseEvent(self, event):
         # type: (QGraphicsSceneMouseEvent) -> bool
         if self.tmp_link_item is not None:
-            self.force_link_dialog = bool(event.modifiers() & Qt.ShiftModifier)
             item = self.target_node_item_at(event.scenePos())
             node = None  # type: Optional[Node]
             stack = self.document.undoStack()
@@ -581,7 +579,7 @@ class NewLinkAction(UserInteraction):
             # to SchemeLinks later
             links_to_add = []     # type: List[Link]
             links_to_remove = []  # type: List[Link]
-            show_link_dialog = self.force_link_dialog
+            show_link_dialog = False
 
             # Ambiguous new link request.
             if len(possible) >= 2:
@@ -659,8 +657,6 @@ class NewLinkAction(UserInteraction):
             log.error("An error occurred during the creation of a new link.",
                       exc_info=True)
             self.cancel()
-        finally:
-            self.force_link_dialog = False
 
     def edit_links(
             self,

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -267,8 +267,6 @@ class NewLinkAction(UserInteraction):
 
     def __init__(self, document, *args, **kwargs):
         super().__init__(document, *args, **kwargs)
-        self.source_item = None  # type: Optional[items.NodeItem]
-        self.sink_item = None    # type: Optional[items.NodeItem]
         self.from_item = None    # type: Optional[items.NodeItem]
         self.direction = 0   # type: int
         self.force_link_dialog = False
@@ -369,10 +367,8 @@ class NewLinkAction(UserInteraction):
             self.from_item = anchor_item.parentNodeItem()
             if isinstance(anchor_item, items.SourceAnchorItem):
                 self.direction = NewLinkAction.FROM_SOURCE
-                self.source_item = self.from_item
             else:
                 self.direction = NewLinkAction.FROM_SINK
-                self.sink_item = self.from_item
 
             event.accept()
 
@@ -406,9 +402,9 @@ class NewLinkAction(UserInteraction):
 
             # Set the `fixed` end of the temp link (where the drag started).
             if self.direction == self.FROM_SOURCE:
-                self.tmp_link_item.setSourceItem(self.source_item)
+                self.tmp_link_item.setSourceItem(self.from_item)
             else:
-                self.tmp_link_item.setSinkItem(self.sink_item)
+                self.tmp_link_item.setSinkItem(self.from_item)
 
             self.set_link_target_anchor(self.cursor_anchor_point)
             self.scene.addItem(self.tmp_link_item)
@@ -428,7 +424,7 @@ class NewLinkAction(UserInteraction):
             self.current_target_item = None
 
         if item is not None and item is not self.from_item:
-            # The mouse is over an node item (different from the starting node)
+            # The mouse is over a node item (different from the starting node)
             if self.current_target_item is item:
                 # Avoid reseting the points
                 pass
@@ -482,11 +478,11 @@ class NewLinkAction(UserInteraction):
 
             if node is not None:
                 if self.direction == self.FROM_SOURCE:
-                    source_node = self.scene.node_for_item(self.source_item)
+                    source_node = self.scene.node_for_item(self.from_item)
                     sink_node = node
                 else:
                     source_node = node
-                    sink_node = self.scene.node_for_item(self.sink_item)
+                    sink_node = self.scene.node_for_item(self.from_item)
                 self.suggestions.set_direction(self.direction)
                 self.connect_nodes(source_node, sink_node)
 

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -465,6 +465,10 @@ class NewLinkAction(UserInteraction):
             # an empty scene spot.
             log.info("%r is no longer the target.", self.current_target_item)
             self.remove_tmp_anchor()
+            if self.direction == self.FROM_SOURCE:
+                self.current_target_item.inputAnchorItem.setHovered(False)
+            else:
+                self.current_target_item.outputAnchorItem.setHovered(False)
             self.current_target_item = None
 
         if item is not None and item is not self.from_item:
@@ -477,6 +481,10 @@ class NewLinkAction(UserInteraction):
             elif self.can_connect(item):
                 # Mouse is over a new item
                 log.info("%r is the new target.", item)
+                if self.direction == self.FROM_SOURCE:
+                    item.inputAnchorItem.setHovered(True)
+                else:
+                    item.outputAnchorItem.setHovered(True)
                 scenePos = event.scenePos()
                 self.create_tmp_anchor(item, scenePos)
                 self.set_link_target_anchor(

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -438,10 +438,11 @@ class NewLinkAction(UserInteraction):
                 anchor = self.from_item.outputAnchorItem
             else:
                 anchor = self.from_item.inputAnchorItem
+            anchor.setHovered(False)
 
             if anchor.anchorOpen():
                 signal = anchor.signalAtPos(scenePos)
-                anchor.setKeepAnchorOpen(True)
+                anchor.setKeepAnchorOpen(signal)
             else:
                 signal = None
             self.from_signal = signal
@@ -785,6 +786,7 @@ class NewLinkAction(UserInteraction):
     def end(self):
         # type: () -> None
         self.cleanup()
+        self.reset_open_anchor()
         # Remove the help tip set in mousePressEvent
         self.macro = None
         helpevent = QuickHelpTipEvent("", "")
@@ -794,6 +796,7 @@ class NewLinkAction(UserInteraction):
     def cancel(self, reason=UserInteraction.OtherReason):
         # type: (int) -> None
         self.cleanup()
+        self.reset_open_anchor()
         super().cancel(reason)
 
     def cleanup(self):
@@ -801,11 +804,6 @@ class NewLinkAction(UserInteraction):
         """
         Cleanup all temporary items in the scene that are left.
         """
-        if self.from_item:
-            if self.direction == self.FROM_SOURCE:
-                self.from_item.outputAnchorItem.setKeepAnchorOpen(False)
-            else:
-                self.from_item.inputAnchorItem.setKeepAnchorOpen(False)
         if self.tmp_link_item:
             self.tmp_link_item.setSinkItem(None)
             self.tmp_link_item.setSourceItem(None)
@@ -822,6 +820,17 @@ class NewLinkAction(UserInteraction):
         if self.cursor_anchor_point and self.cursor_anchor_point.scene():
             self.scene.removeItem(self.cursor_anchor_point)
             self.cursor_anchor_point = None
+
+    def reset_open_anchor(self):
+        """
+        This isn't part of cleanup, because it should retain its value
+        until the link is created.
+        """
+        if self.direction == self.FROM_SOURCE:
+            anchor = self.from_item.outputAnchorItem
+        else:
+            anchor = self.from_item.inputAnchorItem
+        anchor.setKeepAnchorOpen(None)
 
 
 def edit_links(

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1482,6 +1482,8 @@ class SchemeEditWidget(QWidget):
 
     def sceneKeyPressEvent(self, event):
         # type: (QKeyEvent) -> bool
+        self.__updateOpenWidgetAnchors(event)
+
         scene = self.__scene
         if scene.user_interaction_handler:
             return False
@@ -1532,7 +1534,17 @@ class SchemeEditWidget(QWidget):
 
     def sceneKeyReleaseEvent(self, event):
         # type: (QKeyEvent) -> bool
+        self.__updateOpenWidgetAnchors(event)
         return False
+
+    def __updateOpenWidgetAnchors(self, event=None):
+        scene = self.__scene
+        # Open widget anchors on shift. New link action should work during this
+        if event:
+            open = event.modifiers() == Qt.ShiftModifier
+        else:
+            open = QApplication.keyboardModifiers() == Qt.ShiftModifier
+        scene.set_widget_anchors_open(open)
 
     def sceneContextMenuEvent(self, event):
         # type: (QGraphicsSceneContextMenuEvent) -> bool
@@ -1610,6 +1622,7 @@ class SchemeEditWidget(QWidget):
         # type: () -> None
         self.sender().ended.disconnect(self.__onInteractionEnded)
         set_enabled_all(self.__disruptiveActions, True)
+        self.__updateOpenWidgetAnchors()
 
     def __onSelectionChanged(self):
         # type: () -> None

--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -612,7 +612,8 @@ class Scheme(QObject):
 
         return result
 
-    def propose_links(self, source_node, sink_node):
+    def propose_links(self, source_node, sink_node,
+                            source_signal=None, sink_signal=None):
         # type: (SchemeNode, SchemeNode) -> List[Tuple[OutputSignal, InputSignal, int]]
         """
         Return a list of ordered (:class:`OutputSignal`,
@@ -632,8 +633,10 @@ class Scheme(QObject):
             # Loops are not enabled.
             return []
 
-        outputs = source_node.output_channels()
-        inputs = sink_node.input_channels()
+        outputs = [source_signal] if source_signal \
+             else source_node.output_channels()
+        inputs = [sink_signal] if sink_signal \
+            else sink_node.input_channels()
 
         # Get existing links to sink channels that are Single.
         links = self.find_links(None, None, sink_node)

--- a/orangecanvas/utils/mathutils.py
+++ b/orangecanvas/utils/mathutils.py
@@ -1,0 +1,24 @@
+def interp1d(start, end):
+    memo = {}
+    if (tuple(start), tuple(end)) in memo:
+        return memo[(start, end)]
+
+    diff = [e - s
+            for e, s in zip(end, start)]
+
+    r_start, r_end = 0, 1
+    r_diff = r_end - r_start
+
+    def interp(num):
+        nonlocal memo
+
+        if num in memo:
+            return memo[num]
+        percent = (num - r_start) / r_diff
+        val = [s + d * percent
+               for s, d in zip(start, diff)]
+        memo[num] = val
+        return val
+
+    memo[(tuple(start), tuple(end))] = interp
+    return interp


### PR DESCRIPTION
![ezgif-7-325db6428606](https://user-images.githubusercontent.com/24586651/98484579-e44ced80-2210-11eb-8339-8e229d5a7f36.gif)

Hold shift to show the currently hovered anchor's channels. You can drag from channel to channel, channel to node, node to channel, or from channel to anywhere (and add a new node).

This isn't quite finished, but it's far enough to be usable. Anyone want to give it a try? :)

TODO are tests, some stylistic changes, and fixing some bugs, like this one:
![ezgif-3-e2485b375c21](https://user-images.githubusercontent.com/24586651/98484656-545b7380-2211-11eb-94bf-112da62798bd.gif)
This will need to be fixed in `orangecanvas.canvas.layout.AnchorLayout`, specifically, instead of getting the points' positions directly from the objects' scene positions, it will need to map the positions from the uniform positions' percentage values on the anchor. (just writing this down for future reference)