### PR TITLE
canvasmain: Widen toolbox icons slightly

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -272,7 +272,7 @@ class CanvasMainWindow(QMainWindow):
         self.widgets_tool_box.setObjectName("canvas-toolbox")
         self.widgets_tool_box.setTabButtonHeight(30)
         self.widgets_tool_box.setTabIconSize(QSize(26, 26))
-        self.widgets_tool_box.setButtonSize(QSize(64, 84))
+        self.widgets_tool_box.setButtonSize(QSize(68, 84))
         self.widgets_tool_box.setIconSize(QSize(48, 48))
 
         self.widgets_tool_box.triggered.connect(

--- a/orangecanvas/gui/toolgrid.py
+++ b/orangecanvas/gui/toolgrid.py
@@ -102,7 +102,7 @@ class ToolGridButton(QToolButton):
 
         # elide the end of each line if too long
         lines = [
-            fm.elidedText(l, Qt.ElideRight, self.width())
+            fm.elidedText(l, Qt.ElideRight, self.width() - margin)
             for l in lines
         ]
 


### PR DESCRIPTION
Last time on toolbox chronicles, elision was eliminated, but some of the names were pretty wide and close to the button edges. This change widens the toolbox by 12 pixels to make it prettier.

Also, if the Principal Component Analysis widget is called PCA, and the Multi-Dimensional Scaling widget is called MDS, can we call the Stochastic Gradient Descent widget SGD? Either by setting a short name (visible only in the toolbox), or renaming the widget itself. We could also rename PCA/MDS to their full names and set their short name to PCA/MDS.