### PR TITLE
nodeitem: Use 'pallete(base)' for background color

### DIFF
--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -680,7 +680,7 @@ class NodeAnchorItem(GraphicsPathObject):
 
             text = s.name
             lbl.setHtml('<div align="' + ('left' if alignLeft else 'right') +
-                        '" style="font-size: small; background-color: white;" >{0}</div>'
+                        '" style="font-size: small; background-color: palette(base);" >{0}</div>'
                         .format(text))
 
             cperc = self.__getChannelPercent(s)


### PR DESCRIPTION
### Issue

The channel anchor are unreadable when using dark style.

![anchors](https://user-images.githubusercontent.com/4716745/106434265-98a58b00-6471-11eb-9ebe-36b0a127c20d.png)

### Changes

Use 'pallete(base)' for background color instead of fixed white color. 
