### PR TITLE
interactions: Fix nodes sometimes not adding

### DIFF
--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -472,11 +472,11 @@ class NewLinkAction(UserInteraction):
                 anchor = self.current_target_item.inputAnchorItem
             else:
                 anchor = self.current_target_item.outputAnchorItem
-            if not self.showing_incompatible_widget:
-                self.remove_tmp_anchor()
-                self.showing_incompatible_widget = True
-            else:
+            if self.showing_incompatible_widget:
                 anchor.setIncompatible(False)
+                self.showing_incompatible_widget = False
+            else:
+                self.remove_tmp_anchor()
             anchor.setHovered(False)
             anchor.setCompatibleSignals(None)
             self.current_target_item = None


### PR DESCRIPTION
If you try to add a new node via releasing a link on blank canvas, but you first hover over a widget's anchor, it silently fails to add the node.

This PR should fix this behavior.