### PR TITLE
quickmenu: do not sort subword matches preferentially

### DIFF
--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -548,10 +548,8 @@ class SortFilterProxyModel(QSortFilterProxyModel):
         sorting_predicates = [
             lambda t: query == t,  # full title match
             lambda t: query == t.replace(' ', ''),  # full title match no spaces
-            lambda t: query in t.split(' '),  # full subword match
             lambda t: t.startswith(query),  # startswith title match
             lambda t: t.replace(' ', '').startswith(query),  # startswith title match no spaces
-            lambda t: any(w.startswith(query) for w in t.split(' '))  # startswith subword match
         ]
 
         for p in sorting_predicates:


### PR DESCRIPTION
Problem: as I started typing "dat" I saw "datasets" as a top option. Then I added "a", so I had "data", which put all widgets with "data" in front. I started pressing enter before typing the final "a", because the correct widget was already selected. I got something else instead of the "Datasets" I really wanted. :(

This PR decreases re-sorting frequency while still keeping the most obvious matches on top.