### PR TITLE
[FIX] Inline node edit palette and focus

### DIFF
--- a/orangecanvas/canvas/items/graphicstextitem.py
+++ b/orangecanvas/canvas/items/graphicstextitem.py
@@ -108,7 +108,8 @@ class GraphicsTextItem(QGraphicsTextItem):
 
     def __updateDefaultTextColor(self):
         # type: () -> None
-        if self.__styleState & QStyle.State_Selected:
+        if self.__styleState & QStyle.State_Selected \
+                and not self.__styleState & QStyle.State_Editing:
             role = QPalette.HighlightedText
         else:
             role = QPalette.WindowText
@@ -336,6 +337,7 @@ class GraphicsTextEdit(GraphicsTextItem):
         self.__editing = True
         self.__textInteractionFlags = self.textInteractionFlags()
         self.setTextInteractionFlags(Qt.TextEditorInteraction)
+        self.setStyleState(self.styleState() | QStyle.State_Editing)
         self.setFocus(focusReason)
         self.editingStarted.emit()
 
@@ -343,6 +345,7 @@ class GraphicsTextEdit(GraphicsTextItem):
         self.__editing = False
         self.clearSelection()
         self.setTextInteractionFlags(self.__textInteractionFlags)
+        self.setStyleState(self.styleState() & ~QStyle.State_Editing)
         self.editingFinished.emit()
 
 

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1244,6 +1244,7 @@ class SchemeEditWidget(QWidget):
         """
         Edit (rename) the `node`'s title.
         """
+        self.__view.setFocus(Qt.OtherFocusReason)
         scene = self.__scene
         item = scene.item_for_node(node)
         item.editTitle()


### PR DESCRIPTION
### Issue

* On Windows the text is invisible (same color as the background) when trying to edit the node name.
* Drag/Drop a new node from the toolbox, press edit shortcut (<kbd>F2</kbd>), the name has visual appearance as editable, but does not actually have the keyboard focus, which remains with the toolbox.

### Changes

* Update the item text color when editing.
* Ensure the view has focus when starting the node name edit.
