### PR TITLE
[FIX] Workflow preview render

### DIFF
--- a/orangecanvas/preview/scanner.py
+++ b/orangecanvas/preview/scanner.py
@@ -140,6 +140,7 @@ def scheme_svg_thumbnail(scheme_file):
     tmp_scene = scene.CanvasScene()
     tmp_scene.set_channel_names_visible(False)
     tmp_scene.set_registry(global_registry())
+    tmp_scene.set_node_animation_enabled(False)
     tmp_scene.set_scheme(scheme)
 
     # Force the anchor point layout.

--- a/orangecanvas/preview/scanner.py
+++ b/orangecanvas/preview/scanner.py
@@ -145,6 +145,8 @@ def scheme_svg_thumbnail(scheme_file):
 
     # Force the anchor point layout.
     tmp_scene.anchor_layout().activate()
+    # Last added node is auto-selected. Need to clear.
+    tmp_scene.clearSelection()
 
     svg = scene.grab_svg(tmp_scene)
     tmp_scene.clear()


### PR DESCRIPTION
#### Issue

* Preview render (Browse Recent, Example Workflows) renders node anchors in the wrong position
* One node in rendered selected

![Screen Shot 2021-03-25 at 11 18 54](https://user-images.githubusercontent.com/4716745/112457317-ef399200-8d5b-11eb-8d65-003139cf5958.png)

#### Changes

* Disable animations when rendering preview
* Deselect all items

