### PR TITLE
[FIX] schemeedit: Begin name edit only on left button click

### DIFF
--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1417,6 +1417,7 @@ class SchemeEditWidget(QWidget):
         any_item = scene.item_at(pos)
         # start node name edit on selected clicked
         if sys.platform == "darwin" \
+                and event.button() == Qt.LeftButton \
                 and isinstance(any_item, items.nodeitem.GraphicsTextEdit) \
                 and isinstance(any_item.parentItem(), items.NodeItem):
             node = scene.node_for_item(any_item.parentItem())


### PR DESCRIPTION
### Issue

'Inline' node title editing via right click when selected (https://github.com/biolab/orange-canvas-core/pull/172) starts edit and immediately opens a context menu. Only left click should start edit. <s>Can also crash on Big Sur (https://github.com/biolab/orange3/issues/5379)</s> (QTBUG-88309 is the cause; present in Qt >=5.15.1)

### Changes

Only start edit on left button click.