### PR TITLE
[FIX] Segfault on right click on editable text item

### DIFF
--- a/orangecanvas/canvas/items/tests/test_graphicstextitem.py
+++ b/orangecanvas/canvas/items/tests/test_graphicstextitem.py
@@ -1,0 +1,101 @@
+from typing import Optional
+from unittest import skipIf
+
+from AnyQt.QtCore import QPointF, QPoint, Qt
+from AnyQt.QtTest import QSignalSpy
+from AnyQt.QtWidgets import QGraphicsScene, QGraphicsView, QGraphicsItem, QMenu, \
+    QAction, QApplication, QWidget, QGraphicsTextItem
+
+from orangecanvas.gui.test import QAppTestCase, contextMenu
+from orangecanvas.canvas.items.graphicstextitem import GraphicsTextItem
+from orangecanvas.utils import findf
+
+
+@skipIf(GraphicsTextItem.contextMenuEvent == QGraphicsTextItem.contextMenuEvent,
+        "contextMenuEvent is not reimplemented")
+class TestGraphicsTextItem(QAppTestCase):
+    def setUp(self):
+        super().setUp()
+        self.scene = QGraphicsScene()
+        self.view = QGraphicsView(self.scene)
+        self.item = GraphicsTextItem()
+        self.item.setPlainText("AAA")
+        self.item.setTextInteractionFlags(Qt.TextEditable)
+        self.scene.addItem(self.item)
+        self.view.setFocus()
+
+    def tearDown(self):
+        self.scene.clear()
+        self.view.deleteLater()
+        del self.scene
+        del self.view
+        super().tearDown()
+
+    def test_item_context_menu(self):
+        item = self.item
+        menu = self._context_menu()
+        self.assertFalse(item.textCursor().hasSelection())
+        ac = find_action(menu, "select-all")
+        self.assertTrue(ac.isEnabled())
+        ac.trigger()
+        self.assertTrue(item.textCursor().hasSelection())
+
+    def test_copy_cut_paste(self):
+        item = self.item
+        cb = QApplication.clipboard()
+
+        c = item.textCursor()
+        c.select(c.Document)
+        item.setTextCursor(c)
+
+        menu = self._context_menu()
+        ac = find_action(menu, "edit-copy")
+        spy = QSignalSpy(cb.dataChanged)
+        ac.trigger()
+        self.assertTrue(len(spy) or spy.wait())
+
+        ac = find_action(menu, "edit-cut")
+        spy = QSignalSpy(cb.dataChanged)
+        ac.trigger()
+        self.assertTrue(len(spy) or spy.wait())
+        self.assertEqual(item.toPlainText(), "")
+
+        ac = find_action(menu, "edit-paste")
+        ac.trigger()
+        self.assertEqual(item.toPlainText(), "AAA")
+
+    def test_context_menu_delete(self):
+        item = self.item
+        c = item.textCursor()
+        c.select(c.Document)
+        item.setTextCursor(c)
+
+        menu = self._context_menu()
+        ac = find_action(menu, "edit-delete")
+        ac.trigger()
+        self.assertEqual(self.item.toPlainText(), "")
+
+    def _context_menu(self):
+        point = map_to_viewport(self.view, self.item, self.item.boundingRect().center())
+        contextMenu(self.view.viewport(), point)
+        return self._get_menu()
+
+    def _get_menu(self) -> QMenu:
+        menu = findf(
+            self.app.topLevelWidgets(),
+            lambda w: isinstance(w, QMenu) and w.parent() is self.view.viewport()
+        )
+        assert menu is not None
+        return menu
+
+
+def map_to_viewport(view: QGraphicsView, item: QGraphicsItem, point: QPointF) -> QPoint:
+    point = item.mapToScene(point)
+    return view.mapFromScene(point)
+
+
+def find_action(widget, name):  # type: (QWidget, str) -> Optional[QAction]
+    for a in widget.actions():
+        if a.objectName() == name:
+            return a
+    return None

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1417,6 +1417,7 @@ class SchemeEditWidget(QWidget):
         any_item = scene.item_at(pos)
         # start node name edit on selected clicked
         if sys.platform == "darwin" \
+                and event.button() == Qt.LeftButton \
                 and isinstance(any_item, items.nodeitem.GraphicsTextEdit) \
                 and isinstance(any_item.parentItem(), items.NodeItem):
             node = scene.node_for_item(any_item.parentItem())

--- a/orangecanvas/document/tests/test_schemeedit.py
+++ b/orangecanvas/document/tests/test_schemeedit.py
@@ -20,7 +20,8 @@ from ...canvas import items
 from ...scheme import Scheme, SchemeNode, SchemeLink, SchemeTextAnnotation, \
                       SchemeArrowAnnotation
 from ...registry.tests import small_testing_registry
-from ...gui.test import QAppTestCase, mouseMove, dragDrop, dragEnterLeave
+from ...gui.test import QAppTestCase, mouseMove, dragDrop, dragEnterLeave, \
+    contextMenu
 from ...utils import findf
 from ...scheme.tests.test_widgetmanager import TestingWidgetManager
 
@@ -223,6 +224,9 @@ class TestSchemeEdit(QAppTestCase):
         w = self.w
         scene = w.scene()
         view = w.view()
+        w.show()
+        w.raise_()
+        w.activateWindow()
         node = SchemeNode(self.reg.widget("one"), title="A")
         w.addNode(node)
         w.selectAll()
@@ -233,6 +237,7 @@ class TestSchemeEdit(QAppTestCase):
         point = view.mapFromScene(point)
         QTest.mouseClick(view.viewport(), Qt.LeftButton, Qt.NoModifier, point)
         self.assertTrue(item.captionTextItem.isEditing())
+        contextMenu(view.viewport(), point)
 
     def test_arrow_annotation_action(self):
         w = self.w

--- a/orangecanvas/gui/test.py
+++ b/orangecanvas/gui/test.py
@@ -11,7 +11,8 @@ from AnyQt.QtCore import (
     QCoreApplication, QTimer, QStandardPaths, QPoint, Qt, QMimeData
 )
 from AnyQt.QtGui import (
-    QMouseEvent, QDragEnterEvent, QDropEvent, QDragMoveEvent, QDragLeaveEvent
+    QMouseEvent, QDragEnterEvent, QDropEvent, QDragMoveEvent, QDragLeaveEvent,
+    QContextMenuEvent
 )
 from AnyQt.QtTest import QTest
 from AnyQt.QtCore import PYQT_VERSION
@@ -94,6 +95,18 @@ def mouseMove(widget, buttons, modifier=Qt.NoModifier, pos=QPoint(), delay=-1):
         QTest.qWait(delay)
 
     QCoreApplication.sendEvent(widget, me)
+
+
+def contextMenu(widget: QWidget, pos: QPoint, delay=-1) -> None:
+    """
+    Simulates a contextMenuEvent on the widget.
+    """
+    ev = QContextMenuEvent(
+        QContextMenuEvent.Mouse, pos, widget.mapToGlobal(pos)
+    )
+    if delay > 0:
+        QTest.qWait(delay)
+    QCoreApplication.sendEvent(widget, ev)
 
 
 def dragDrop(


### PR DESCRIPTION
### Issue

Fixes: https://github.com/biolab/orange3/issues/5379

### Changes

Reimplement QGraphicsTextItem.contextMenuEvent for Qt >= 5.15.1,<6.0.0

Opening a context menu on an editable QGraphicsTextItem segfaults in Qt >=5.15.1,<6.0.0 ([QTBUG-88309](https://bugreports.qt.io/browse/QTBUG-88309))

