### PR TITLE
[FIX] after_exit: Pipe output to /dev/null

### DIFF
--- a/orangecanvas/utils/after_exit.py
+++ b/orangecanvas/utils/after_exit.py
@@ -87,8 +87,9 @@ def main(argv):
 
     if ns.arg:
         log.info("Starting new process with cmd: %r", ns.arg)
-        kwargs = {}
-        p = sh.create_process(ns.arg, **kwargs)
+        p = sh.create_process(
+            ns.arg, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
         main.p = p
     return 0
 


### PR DESCRIPTION
### Issue

Ref: https://github.com/biolab/orange3/issues/5356

### Changes

Pipe output to /dev/null
