### PR TITLE
Scheme: Add node_properties_changed signal

### DIFF
--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -96,6 +96,9 @@ class Scheme(QObject):
     #: Signal emitted when the associated runtime environment changes
     runtime_env_changed = Signal(str, object, object)
 
+    # Signal emitted by subclass upon a detected settings change
+    node_properties_changed = Signal()
+
     def __init__(self, parent=None, title="", description="", env={},
                  **kwargs):
         # type: (Optional[QObject], str, str, Mapping[str, Any], Any) -> None

--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -93,7 +93,7 @@ class Scheme(QObject):
     # Signal emitted when the description of scheme changes.
     description_changed = Signal(str)
 
-    #: Signal emitted when the associated runtime environment changes
+    # Signal emitted when the associated runtime environment changes
     runtime_env_changed = Signal(str, object, object)
 
     # Signal emitted by subclass upon a detected settings change


### PR DESCRIPTION
Is required by https://github.com/biolab/orange-widget-base/pull/151

Until now, canvas-core was not aware of changes to settings in widget-base. It only knew to call `sync_node_properties` to pack Settings when saving. This PR adds a `node_properties_changed` signal, intended to be emitted by subclasses of Scheme. (see corresponding widget-base PR)

I needed to solve this for the tutorial implementation. However, it should make the following UX improvements trivial to implement:
- [ ] save crash recovery state also on Setting change, not just workflow change (`CanvasMainWindow.save_swp`)
- [ ] set SchemeEditWidget as modified on Setting change

Also, it would be sensible to:
- [ ] save widget geometry on `settingsAboutTobePacked` instead of tying it to hideEvent/moveEvent/...
- [ ] call `sync_node_properties` when a widget's window is unfocused (intrinsically calls `settingsAboutToBePacked`)