### PR TITLE
[FIX] Category popup geometry error

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -927,6 +927,7 @@ class CanvasMainWindow(QMainWindow):
             if i != -1:
                 popup.setModel(model)
                 popup.setRootIndex(model.index(i, 0))
+                popup.adjustSize()
                 button = self.quick_category.buttonForAction(action)
                 pos = popup_position_from_source(popup, button)
                 action = popup.exec(pos)

--- a/orangecanvas/application/canvastooldock.py
+++ b/orangecanvas/application/canvastooldock.py
@@ -648,20 +648,13 @@ def widget_popup_geometry(pos, widget):
     if screen is None:
         screen = QApplication.primaryScreen()
     screen_geom = screen.availableGeometry()
-
-    # Adjust the size to fit inside the screen.
-    if size.height() > screen_geom.height():
-        size.setHeight(screen_geom.height())
-    if size.width() > screen_geom.width():
-        size.setWidth(screen_geom.width())
-
+    size = size.boundedTo(screen_geom.size())
     geom = QRect(pos, size)
 
     if geom.top() < screen_geom.top():
-        geom.setTop(screen_geom.top())
-
+        geom.moveTop(screen_geom.top())
     if geom.left() < screen_geom.left():
-        geom.setLeft(screen_geom.left())
+        geom.moveLeft(screen_geom.left())
 
     bottom_margin = screen_geom.bottom() - geom.bottom()
     right_margin = screen_geom.right() - geom.right()

--- a/orangecanvas/application/canvastooldock.py
+++ b/orangecanvas/application/canvastooldock.py
@@ -645,6 +645,8 @@ def widget_popup_geometry(pos, widget):
         size = widget.sizeHint()
 
     screen = QApplication.screenAt(pos)
+    if screen is None:
+        screen = QApplication.primaryScreen()
     screen_geom = screen.availableGeometry()
 
     # Adjust the size to fit inside the screen.

--- a/orangecanvas/application/canvastooldock.py
+++ b/orangecanvas/application/canvastooldock.py
@@ -702,14 +702,14 @@ def popup_position_from_source(popup, source, orientation=Qt.Vertical):
         if dy < 0:
             y = source_rect.top()
         else:
-            y = source_rect.top() - dy
+            y = max(screen_geom.top(), source_rect.top() - dy)
     else:
         # right overflow
         dx = source_rect.left() + size.width() - screen_geom.right()
         if dx < 0:
             x = source_rect.left()
         else:
-            x = source_rect.left() - dx
+            x = max(source_rect.left() - dx, screen_geom.left())
 
         if source_rect.bottom() + size.height() < screen_geom.bottom():
             y = source_rect.bottom()

--- a/orangecanvas/application/tests/test_canvastooldock.py
+++ b/orangecanvas/application/tests/test_canvastooldock.py
@@ -2,8 +2,10 @@
 Test for canvas toolbox.
 """
 
-from AnyQt.QtWidgets import QWidget, QToolBar, QTextEdit, QSplitter
-from AnyQt.QtCore import Qt, QTimer
+from AnyQt.QtWidgets import (
+    QWidget, QToolBar, QTextEdit, QSplitter, QApplication
+)
+from AnyQt.QtCore import Qt, QTimer, QPoint
 
 from ...registry import tests as registry_tests
 from ...registry.qt import QtWidgetRegistry
@@ -11,7 +13,7 @@ from ...gui.dock import CollapsibleDockWidget
 
 from ..canvastooldock import (
     WidgetToolBox, CanvasToolDock, SplitterResizer, QuickCategoryToolbar,
-    CategoryPopupMenu
+    CategoryPopupMenu, popup_position_from_source, widget_popup_geometry
 )
 
 from ...gui import test
@@ -97,5 +99,20 @@ class TestPopupMenu(test.QAppTestCase):
         w = CategoryPopupMenu()
         w.setModel(model)
         w.setRootIndex(model.index(0, 0))
-        w.show()
+        w.popup()
         self.qWait()
+
+    def test_popup_position(self):
+        popup = CategoryPopupMenu()
+        screen = popup.screen()
+        screen_geom = screen.availableGeometry()
+        popup.setMinimumHeight(screen_geom.height() + 20)
+        w = QWidget()
+        w.setGeometry(
+            screen_geom.left() + 100, screen_geom.top() + 100, 20, 20
+        )
+        pos = popup_position_from_source(popup, w)
+        self.assertTrue(screen_geom.contains(pos))
+        pos = QPoint(screen_geom.top() - 100, screen_geom.left() - 100)
+        geom = widget_popup_geometry(pos, popup)
+        self.assertEqual(screen_geom.intersected(geom), geom)


### PR DESCRIPTION
### Issue

In Orange clicking the 'Data' category button in the tooldock when collapsed can raise an exception when the screen is small:
![Screen Shot 2021-06-11 at 09 26 12](https://user-images.githubusercontent.com/4716745/121647991-4c113280-ca97-11eb-9f00-c39502547b92.png)

```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/application/canvasmain.py", line 932, in on_quick_category_action
    action = popup.exec(pos)
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/application/canvastooldock.py", line 519, in exec
    self.popup(pos)
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/application/canvastooldock.py", line 512, in popup
    geom = widget_popup_geometry(pos, self)
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/application/canvastooldock.py", line 648, in widget_popup_geometry
    screen_geom = screen.availableGeometry()
AttributeError: 'NoneType' object has no attribute 'availableGeometry'
-------------------------------------------------------------------------------
```
