### PR TITLE
Scheme: Propose dynamic Input

### DIFF
--- a/orangecanvas/scheme/scheme.py
+++ b/orangecanvas/scheme/scheme.py
@@ -657,16 +657,9 @@ class Scheme(QObject):
                 # Zero weight for explicit links
                 weight = 0
             else:
-                # Does the connection type check (can only ever be False for
-                # dynamic signals)
-                type_checks, _ = _classify_connection(out_c, in_c)
-                # Dynamic signals that require runtime instance type check
-                # are considered last.
-                check = [type_checks,
-                         in_c not in already_connected_sinks,
+                check = [in_c not in already_connected_sinks,
                          bool(in_c.default),
-                         bool(out_c.default)
-                         ]
+                         bool(out_c.default)]
                 weights = [2 ** i for i in range(len(check), 0, -1)]
                 weight = sum([w for w, c in zip(weights, check) if c])
             return weight


### PR DESCRIPTION
#### Issue
When proposing links between source widget outputs and sink widget inputs, 
subclasses of an InputSignal type have smaller weights than the class itself.

Example:
![image](https://user-images.githubusercontent.com/11465003/129019548-72f6216e-11f1-466c-9cd1-31e6605254ed.png)
When connecting a Corpus widget to an Extract Keywords widget, the signals are linked as expected (Corpus (type=Corpus) -> Corpus (type=Corpus)).
When inserting a Data Table widget in between, the signals are linked according to InputSignal type (Selected Data (type=Table) -> Words (type=Table), instead of Selected Data (type=Table) -> Corpus (type=Corpus)).


#### Description of changes
Consider `strict` and `dynamic` source-sink connections equally weighted.
