### PR TITLE
canvasmain: More informative message for unsupported format

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1156,6 +1156,20 @@ class CanvasMainWindow(QMainWindow):
                     return
                 f.seek(0, os.SEEK_SET)
                 new_scheme = self.new_scheme_from_contents_and_path(f, filename)
+        except readwrite.UnsupportedFormatVersionError:
+            mb = QMessageBox(
+                self, windowTitle=self.tr("Error"),
+                icon=QMessageBox.Critical,
+                text=self.tr("Unsupported format version"),
+                informativeText=self.tr(
+                    "The file was saved in a format not supported by this "
+                    "application."
+                ),
+                detailedText="".join(traceback.format_exc()),
+            )
+            mb.setAttribute(Qt.WA_DeleteOnClose)
+            mb.setWindowModality(Qt.WindowModal)
+            mb.open()
         except Exception as err:
             mb = QMessageBox(
                 parent=self, windowTitle=self.tr("Error"),

--- a/orangecanvas/application/tests/test_mainwindow.py
+++ b/orangecanvas/application/tests/test_mainwindow.py
@@ -307,6 +307,18 @@ class TestMainWindowLoad(TestMainWindowBase):
                           return_value=QDialog.Rejected):
             w.install_requirements(["uber-package-shiny", "spasm"])
 
+    def test_load_unsupported_format(self):
+        w = self.w
+        workflow = w.current_document().scheme()
+        with temp_named_file('<scheme version="99.9"></scheme>') as fname, \
+                patch.object(QMessageBox, "open", lambda self: None):
+            w.load_scheme(fname)
+            self.assertIs(w.current_document().scheme(), workflow)
+            dlg = w.findChild(QMessageBox)
+            self.assertIsNotNone(dlg)
+            self.assertIn("99.9", dlg.detailedText())
+            dlg.done(QMessageBox.Ok)
+
 
 TEST_OWS = b"""\
 <?xml version='1.0' encoding='utf-8'?>

--- a/orangecanvas/scheme/readwrite.py
+++ b/orangecanvas/scheme/readwrite.py
@@ -321,30 +321,39 @@ def parse_ows_etree_v_2_0(tree):
     )
 
 
+class InvalidFormatError(ValueError):
+    pass
+
+
+class UnsupportedFormatVersionError(ValueError):
+    pass
+
+
 def parse_ows_stream(stream):
     # type: (Union[AnyStr, IO]) -> _scheme
     doc = parse(stream)
     scheme_el = doc.getroot()
     if scheme_el.tag != "scheme":
-        raise ValueError(
+        raise InvalidFormatError(
             "Invalid Orange Workflow Scheme file"
         )
     version = scheme_el.get("version", None)
     if version is None:
         # Check for "widgets" tag - old Orange<2.7 format
         if scheme_el.find("widgets") is not None:
-            raise ValueError(
+            raise UnsupportedFormatVersionError(
                 "Cannot open Orange Workflow Scheme v1.0. This format is no "
                 "longer supported"
             )
         else:
-            raise ValueError(
+            raise InvalidFormatError(
                 "Invalid Orange Workflow Scheme file (missing version)."
             )
     if version in {"2.0", "2.1"}:
         return parse_ows_etree_v_2_0(doc)
     else:
-        raise ValueError()
+        raise UnsupportedFormatVersionError(
+            f"Unsupported format version {version}")
 
 
 def resolve_replaced(scheme_desc: _scheme, registry: WidgetRegistry) -> _scheme:


### PR DESCRIPTION
### Issue

https://github.com/biolab/orange-canvas-core/pull/196  will change serialization format. Workflows saved with future versions will fail to open on older installations.

### Changes

Display a more informative message when encountering an unsupported format version.