### PR TITLE
ci: Use qasync<0.19 when testing with PyQt5 5.9

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -19,7 +19,7 @@ jobs:
           # Linux
           - os: ubuntu-16.04
             python-version: 3.6
-            test-env: "PyQt5~=5.9.2"
+            test-env: "PyQt5~=5.9.2 qasync<0.19.0"
 
           - os: ubuntu-18.04
             python-version: 3.7
@@ -36,7 +36,7 @@ jobs:
           # macOS
           - os: macos-10.15
             python-version: 3.6
-            test-env: "PyQt5~=5.9.2"
+            test-env: "PyQt5~=5.9.2 qasync<0.19.0"
 
           - os: macos-10.15
             python-version: 3.7


### PR DESCRIPTION
### Issue 

Tests on master fail since release of qasync 0.19

### Changes

Use qasync<0.19 when testing with PyQt5 5.9; qasync 0.19 is incompatible with PyQt5 5.9