### PR TITLE
[CI] gh-actions: Replace ubuntu-16.04 workers

### DIFF
--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             python: 3.6
 
     steps:

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           # Linux
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             python-version: 3.6
             test-env: "PyQt5~=5.9.2 qasync<0.19.0"
 


### PR DESCRIPTION
ubuntu-16.04 worker is no longer available.