### PR TITLE
config: Add support for setting `AppUserModelID` on windows

### DIFF
--- a/orangecanvas/config.py
+++ b/orangecanvas/config.py
@@ -23,6 +23,7 @@ from AnyQt.QtCore import (
     Qt, QCoreApplication, QPoint, QRect, QSettings, QStandardPaths, QEvent
 )
 
+from .gui.utils import windows_set_current_process_app_user_model_id
 from .utils.settings import Settings, config_slot
 
 if typing.TYPE_CHECKING:
@@ -74,6 +75,11 @@ class Config:
     ApplicationName = ""     # type: str
     #: Version
     ApplicationVersion = ""  # type: str
+    #: AppUserModelID as used on windows for grouping in the task bar
+    #: (https://docs.microsoft.com/en-us/windows/win32/shell/appids).
+    #: This ensures the program does not group with other Python programs
+    #: and gets its own task icon.
+    AppUserModelID = None    # type: Optional[str]
 
     def init(self):
         """
@@ -87,6 +93,10 @@ class Config:
         QCoreApplication.setApplicationVersion(self.ApplicationVersion)
         QSettings.setDefaultFormat(QSettings.IniFormat)
         app = QCoreApplication.instance()
+
+        if self.AppUserModelID:
+            windows_set_current_process_app_user_model_id(self.AppUserModelID)
+
         if app is not None:
             QCoreApplication.sendEvent(app, QEvent(QEvent.PolishRequest))
 

--- a/orangecanvas/gui/utils.py
+++ b/orangecanvas/gui/utils.py
@@ -2,6 +2,7 @@
 Helper utilities
 
 """
+import os
 import sys
 import traceback
 from typing import List
@@ -179,6 +180,21 @@ def is_dwm_compositing_enabled():  # type: () -> bool
     rval = DwmIsCompositionEnabled(ctypes.byref(enabled))
 
     return rval == 0 and enabled.value
+
+
+def windows_set_current_process_app_user_model_id(appid: str):
+    """
+    On Windows set the AppUserModelID to `appid` for the current process.
+
+    Does nothing on other systems
+    """
+    if os.name != "nt":
+        return
+    from ctypes import windll
+    try:
+        windll.shell32.SetCurrentProcessExplicitAppUserModelID(appid)
+    except AttributeError:
+        pass
 
 
 def macos_set_nswindow_tabbing(enable=False):


### PR DESCRIPTION
### Issue

Ref: https://github.com/biolab/orange3/issues/5383

The default task bar grouping (and as a consequence task bar icon) is subject to heuristics by Windows (https://docs.microsoft.com/en-us/windows/win32/shell/appids).

In a fresh Windows system with Python.org supplied Python the takskbar entry for `orange-canvas` process is actually grouped with and uses Python's IDLE editor icon (even if IDLE is not actually running). Reason is probably that IDLE adds windows registry entries for `pythonw` executable for 'Edit with` context menu, and possibly others. This is probably one of the heuristics used by windows.

### Changes

Add support for setting explicit `AppUserModelID` on windows.
