### PR TITLE
add --batch-mode parameter for better scripts support

### DIFF
--- a/orangecanvas/main.py
+++ b/orangecanvas/main.py
@@ -298,6 +298,7 @@ class Main:
         window.setStyleSheet(stylesheet)
         window.output_view().setDocument(self.output)
         window.set_widget_registry(self.registry)
+        window.batch_mode = self.options.batch_mode
         return window
 
     def main_window_stylesheet(self):
@@ -492,6 +493,11 @@ def arg_parser():
     parser.add_argument(
         "--no-welcome", action="store_true",
         help="Don't show welcome dialog."
+    )
+    parser.add_argument(
+        "-b", "--batch-mode", action="store_true",
+        help="Run in batch mode - exit after initial workflow run, "
+        "print errors and return exit nonzero status if any error occured."
     )
     parser.add_argument(
         "--no-splash", action="store_true",

--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -1000,6 +1000,30 @@ class SignalManager(QObject):
         ))
         return ready
 
+    def exit_if_batch_mode(self):
+        if (
+                getattr(self.__workflow.parent(), 'batch_mode', False) and
+                len(self.pending_nodes()) == 0 and
+                len(self.blocking_nodes()) == 0 and
+                len(self.invalidated_nodes()) == 0
+        ):
+            errored = False
+            for node in self.__nodes():
+                for _, message in node._SchemeNode__state_messages.items():
+                    if message.contents:
+                        if message.severity >= 3:
+                            errored = True
+                        severity_str = {
+                            2: 'warning',
+                            3: 'error',
+                            1: 'information',
+                        }[message.severity]
+                        print(
+                            f"'{node.title}' widget {severity_str}:"
+                            f"\t{message.contents}"
+                        )
+            quit(1 if errored else 0)
+
     @Slot()
     def __process_next(self):
         if not self.__state == SignalManager.Running:
@@ -1016,6 +1040,7 @@ class SignalManager(QObject):
             return
 
         if not self.__input_queue:
+            self.exit_if_batch_mode()
             return
         if self.__has_finished:
             self.__has_finished = False


### PR DESCRIPTION
Add parameter `--batch-mode` that exists Orange after the workflow is executed. Orange nonzero status if there was error during running the workflow.

This very simple sollution far from what that @janezd suggested on https://github.com/biolab/orange3/issues/4910. Still this solution can solve many use-cases of scripting workflows, especially with the headless solution I described there.