### PR TITLE
addons: handle add-on names containing hyphens

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -68,10 +68,10 @@ def normalize_name(name):
 def prettify_name(name):
     dash_split = name.split('-')
     # Orange3-ImageAnalytics => ImageAnalytics
-    if len(dash_split) > 1 and dash_split[0].lower() in ['orange', 'orange3']:
-        name = '-'.join(dash_split[1:])
+    orange_prefix = len(dash_split) > 1 and dash_split[0].lower() in ['orange', 'orange3']
+    name = ' '.join(dash_split[1:] if orange_prefix else dash_split)
     # ImageAnalytics => Image Analytics  # while keeping acronyms
-    return re.sub(r"(?<!^)([A-Z][a-z]|(?<=[a-z])[A-Z])", r" \1", name)
+    return re.sub(r"(?<!^)((?<![\s\d])[A-Z][a-z]|(?<=[a-z])[A-Z])", r" \1", name)
 
 
 class Installable(

--- a/orangecanvas/application/tests/test_addons.py
+++ b/orangecanvas/application/tests/test_addons.py
@@ -17,7 +17,7 @@ from orangecanvas.utils.qinvoke import qinvoke
 
 from ..addons import (
     Available, Installed, Installable, Distribution, Requirement, is_updatable,
-    Install, Upgrade, Uninstall,
+    Install, Upgrade, Uninstall, prettify_name,
     installable_items, installable_from_json_response,
     AddonManagerDialog)
 
@@ -76,6 +76,29 @@ class TestUtils(unittest.TestCase):
         })
         self.assertTrue(inst.name, "foo")
         self.assertEqual(inst.version, "1.0")
+
+    def test_prettify_name(self):
+        names = [
+            'AFooBar', 'FooBar', 'Foo-Bar', 'Foo-Bar-FOOBAR',
+            'Foo-bar-foobar', 'Foo', 'FOOBar', 'A4FooBar',
+            '4Foo', 'Foo3Bar'
+        ]
+        pretty_names = [
+            'A Foo Bar', 'Foo Bar', 'Foo Bar', 'Foo Bar FOOBAR',
+            'Foo bar foobar', 'Foo', 'FOO Bar', 'A4Foo Bar',
+            '4Foo', 'Foo3Bar'
+        ]
+
+        for name, pretty_name in zip(names, pretty_names):
+            self.assertEqual(pretty_name, prettify_name(name))
+
+        # test if orange prefix is handled
+        self.assertEqual('Orange', prettify_name('Orange'))
+        self.assertEqual('Orange3', prettify_name('Orange3'))
+        self.assertEqual('Some Addon', prettify_name('Orange-SomeAddon'))
+        self.assertEqual('Text', prettify_name('Orange3-Text'))
+        self.assertEqual('Image Analytics', prettify_name('Orange3-ImageAnalytics'))
+        self.assertEqual('Survival Analysis', prettify_name('Orange3-Survival-Analysis'))
 
 
 @contextmanager


### PR DESCRIPTION
Before:
<img width="185" alt="Screenshot 2021-10-27 at 08 31 16" src="https://user-images.githubusercontent.com/15876321/139013954-31aa1e6c-1214-4c94-ab58-abccad3ebcfc.png">


After:
<img width="183" alt="Screenshot 2021-10-27 at 08 29 51" src="https://user-images.githubusercontent.com/15876321/139013968-4918c24f-33bf-4bca-aa1c-7ab15d165da2.png">


