### PR TITLE
[FIX] readthedocs: Fix build error on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,9 @@
 version: 2
 
 python:
-   version: 3.6
+   version: "3.6"
    install:
       - requirements: docs/requirements-rtd.txt
-      - method: pip
-        path: .
+      # no - method: pip here, -e . is already in docs/requirements-rtd.txt
 
    system_packages: true

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,7 +1,12 @@
 --only-binary PyQt5,numpy
 
 setuptools
-sphinx~=3.2.1
+sphinx~=4.2.0
 sphinx-rtd-theme
 PyQt5~=5.9.2
 AnyQt
+
+# sphinx pins docutils version, but the installation in the RTD worker/config
+# overrides it because docutils is also in our dependencies.
+# https://docs.readthedocs.io/en/stable/faq.html#i-need-to-install-a-package-in-a-environment-with-pinned-versions
+-e .


### PR DESCRIPTION
### Issue

RTD docs build fails due to mismatched sphinx and docutils versions.

### Changes

Move package install into requirements-rtd.txt so it is installed in the same step as sphinx.
