### PR TITLE
Remove deprecation warnings due to QKeyboardSequence

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -420,7 +420,7 @@ class CanvasMainWindow(QMainWindow):
             triggered=self.open_and_freeze_scheme
         )
         self.open_and_freeze_action.setShortcut(
-            QKeySequence(Qt.ControlModifier | Qt.AltModifier | Qt.Key_O)
+            QKeySequence("Ctrl+Alt+O")
         )
         self.close_window_action = QAction(
             self.tr("Close Window"), self,
@@ -526,8 +526,7 @@ class CanvasMainWindow(QMainWindow):
             objectName="recent-action",
             toolTip=self.tr("Browse and open a recent workflow."),
             triggered=self.recent_scheme,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.ShiftModifier |
-                                  Qt.Key_R),
+            shortcut=QKeySequence("Ctrl+Shift+R"),
             icon=canvas_icons("Recent.svg")
         )
         self.reload_last_action = QAction(
@@ -535,7 +534,7 @@ class CanvasMainWindow(QMainWindow):
             objectName="reload-last-action",
             toolTip=self.tr("Reload last open workflow."),
             triggered=self.reload_last,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_R)
+            shortcut=QKeySequence("Ctrl+R")
         )
         self.clear_recent_action = QAction(
             self.tr("Clear Menu"), self,
@@ -548,7 +547,7 @@ class CanvasMainWindow(QMainWindow):
             objectName="show-properties-action",
             toolTip=self.tr("Show workflow properties."),
             triggered=self.show_scheme_properties,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_I),
+            shortcut=QKeySequence("Ctrl+I"),
             icon=canvas_icons("Document Info.svg")
         )
 
@@ -578,7 +577,7 @@ class CanvasMainWindow(QMainWindow):
             self.minimize_action = QAction(
                 self.tr("Minimize"), self,
                 triggered=self.showMinimized,
-                shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_M)
+                shortcut=QKeySequence("Ctrl+M")
             )
             self.zoom_action = QAction(
                 self.tr("Zoom"), self,
@@ -599,8 +598,7 @@ class CanvasMainWindow(QMainWindow):
             self.tr("Expand Tool Dock"), self,
             objectName="toggle-tool-dock-expand",
             checkable=True,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.ShiftModifier |
-                                  Qt.Key_D),
+            shortcut=QKeySequence("Ctrl+Shift+D"),
             triggered=self.set_tool_dock_expanded
         )
         self.toggle_tool_dock_expand.setChecked(True)
@@ -1925,8 +1923,7 @@ class CanvasMainWindow(QMainWindow):
             objectName="welcome-recent-action",
             toolTip=self.tr("Browse and open a recent workflow."),
             triggered=open_recent,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.ShiftModifier |
-                                  Qt.Key_R),
+            shortcut=QKeySequence("Ctrl+Shift+R"),
             icon=canvas_icons("Recent.svg")
         )
 

--- a/orangecanvas/canvas/view.py
+++ b/orangecanvas/canvas/view.py
@@ -49,7 +49,7 @@ class CanvasView(QGraphicsView):
         self.__zoomResetAction = QAction(
             self.tr("Reset Zoom"), self, objectName="action-zoom-reset",
             triggered=self.zoomReset,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_0)
+            shortcut=QKeySequence("Ctrl+0")
         )
 
     def setScene(self, scene):

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -363,7 +363,7 @@ class SchemeEditWidget(QWidget):
 
         shortcuts = [QKeySequence(Qt.Key_Backspace),
                      QKeySequence(Qt.Key_Delete),
-                     QKeySequence(Qt.ControlModifier | Qt.Key_Backspace)]
+                     QKeySequence("Ctrl+Backspace")]
 
         self.__removeSelectedAction.setShortcuts(shortcuts)
 
@@ -419,7 +419,7 @@ class SchemeEditWidget(QWidget):
             self.tr("Duplicate"), self,
             objectName="duplicate-action",
             enabled=False,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_D),
+            shortcut=QKeySequence("Ctrl+D"),
             triggered=self.__duplicateSelected,
         )
 
@@ -427,7 +427,7 @@ class SchemeEditWidget(QWidget):
             self.tr("Copy"), self,
             objectName="copy-action",
             enabled=False,
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_C),
+            shortcut=QKeySequence("Ctrl+C"),
             triggered=self.__copyToClipboard,
         )
 
@@ -435,7 +435,7 @@ class SchemeEditWidget(QWidget):
             self.tr("Paste"), self,
             objectName="paste-action",
             enabled=clipboard_has_format(MimeTypeWorkflowFragment),
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_V),
+            shortcut=QKeySequence("Ctrl+V"),
             triggered=self.__pasteFromClipboard,
         )
         QApplication.clipboard().dataChanged.connect(
@@ -506,7 +506,7 @@ class SchemeEditWidget(QWidget):
         self.__raiseWidgetsAction = QAction(
             self.tr("Bring Widgets to Front"), self,
             objectName="bring-widgets-to-front-action",
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_Down),
+            shortcut=QKeySequence("Ctrl+Down"),
             shortcutContext=Qt.WindowShortcut,
         )
         self.__raiseWidgetsAction.triggered.connect(self.__raiseToFont)

--- a/orangecanvas/gui/examples/dock.py
+++ b/orangecanvas/gui/examples/dock.py
@@ -28,7 +28,7 @@ def main(argv):
 
     a = QAction(
         "Expand", mw, checkable=True,
-        shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_D)
+        shortcut=QKeySequence("Ctrl+D")
     )
     a.triggered[bool].connect(dock.setExpanded)
     mw.addAction(a)

--- a/orangecanvas/scheme/widgetmanager.py
+++ b/orangecanvas/scheme/widgetmanager.py
@@ -267,15 +267,14 @@ class WidgetManager(QObject):
             self.tr("Raise Canvas to Front"), w,
             objectName="action-canvas-raise-canvas",
             toolTip=self.tr("Raise containing canvas workflow window"),
-            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_Up)
+            shortcut=QKeySequence("Ctrl+Up")
         )
         raise_canvas.triggered.connect(self.__on_activate_parent)
         raise_descendants = QAction(
             self.tr("Raise Descendants"), w,
             objectName="action-canvas-raise-descendants",
             toolTip=self.tr("Raise all immediate descendants of this node"),
-            shortcut=QKeySequence(
-                Qt.ControlModifier | Qt.ShiftModifier | Qt.Key_Right)
+            shortcut=QKeySequence("Ctrl+Shift+Right")
         )
         raise_descendants.triggered.connect(
             partial(self.__on_raise_descendants, node)
@@ -284,8 +283,7 @@ class WidgetManager(QObject):
             self.tr("Raise Ancestors"), w,
             objectName="action-canvas-raise-ancestors",
             toolTip=self.tr("Raise all immediate ancestors of this node"),
-            shortcut=QKeySequence(
-                Qt.ControlModifier | Qt.ShiftModifier | Qt.Key_Left)
+            shortcut=QKeySequence("Ctrl+Shift+Left")
         )
         raise_ancestors.triggered.connect(
             partial(self.__on_raise_ancestors, node)


### PR DESCRIPTION
##### Issue
Our logs are full of warnings like:

DeprecationWarning: an integer is required (got type KeyboardModifiers).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python