### PR TITLE
[FIX] Fix error on link create

### DIFF
--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -569,6 +569,7 @@ class NewLinkAction(UserInteraction):
                 self.set_link_target_anchor(self.cursor_anchor_point)
                 self.current_target_item = item
         else:
+            self.showing_incompatible_widget = item is not None
             self.set_link_target_anchor(self.cursor_anchor_point)
 
         self.cursor_anchor_point.setPos(event.scenePos())

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -361,7 +361,7 @@ class NewLinkAction(UserInteraction):
                                                        self.__target_compatible_signals)
         self.tmp_anchor_point.setSignal(signal)
 
-    def create_tmp_anchor(self, item, scenePos, viableLinks=None):
+    def create_tmp_anchor(self, item, scenePos):
         # type: (items.NodeItem, QPointF) -> None
         """
         Create a new tmp anchor at the `item` (:class:`NodeItem`).


### PR DESCRIPTION
When in [open anchors mode](https://github.com/biolab/orange-canvas-core/pull/215) dragging a outgoing link back onto the node
itself would raise an: 
    
    ValueError: min() arg is an empty sequence

in AnchorItem.signalAtPos

```
---------------------------- ValueError Exception -----------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange-canvas-core/orangecanvas/canvas/scene.py", line 848, in mouseReleaseEvent
    self.user_interaction_handler.mouseReleaseEvent(event):
  File "/home/ales/devel/orange-canvas-core/orangecanvas/document/interactions.py", line 610, in mouseReleaseEvent
    sink_signal = item.inputAnchorItem.signalAtPos(
  File "/home/ales/devel/orange-canvas-core/orangecanvas/canvas/items/nodeitem.py", line 1024, in signalAtPos
    return min(signalsToFind, key=signalLengthToPos)
ValueError: min() arg is an empty sequence
-------------------------------------------------------------------------------
```
![link-error](https://user-images.githubusercontent.com/4716745/147943928-4003d96f-2d51-40af-a5b3-85b61059f341.gif)

