### PR TITLE
[FIX] annotationitem: Fix a implicit int cast error

### DIFF
--- a/orangecanvas/canvas/items/annotationitem.py
+++ b/orangecanvas/canvas/items/annotationitem.py
@@ -9,7 +9,7 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtGui import (
     QPainterPath, QPainterPathStroker, QPolygonF, QColor, QPen, QBrush,
-    QPalette, QPainter, QTextDocument, QTextCursor
+    QPalette, QPainter, QTextDocument, QTextCursor, QFontMetricsF
 )
 from AnyQt.QtCore import (
     Qt, QPointF, QSizeF, QRectF, QLineF, QEvent, QMetaObject, QObject
@@ -74,13 +74,15 @@ class GraphicsTextEdit(GraphicsTextEdit):
         # Draw placeholder text if necessary
         if not (self.toPlainText() and self.toHtml()) and \
                 self.__placeholderText and \
-                not (self.hasFocus() and \
+                not (self.hasFocus() and
                      self.textInteractionFlags() & Qt.TextEditable):
             brect = self.boundingRect()
-            painter.setFont(self.font())
-            metrics = painter.fontMetrics()
-            text = metrics.elidedText(self.__placeholderText, Qt.ElideRight,
-                                      brect.width())
+            font = self.font()
+            painter.setFont(font)
+            metrics = QFontMetricsF(font)
+            text = metrics.elidedText(
+                self.__placeholderText, Qt.ElideRight, brect.width()
+            )
             color = self.defaultTextColor()
             color.setAlpha(min(color.alpha(), 150))
             painter.setPen(QPen(color))

--- a/orangecanvas/canvas/items/tests/test_annotationitem.py
+++ b/orangecanvas/canvas/items/tests/test_annotationitem.py
@@ -2,7 +2,7 @@ import math
 import time
 
 from AnyQt.QtGui import QColor
-from AnyQt.QtCore import Qt, QRectF, QLineF, QTimer
+from AnyQt.QtCore import Qt, QRectF, QLineF, QTimer, QPointF
 
 from ..annotationitem import TextAnnotation, ArrowAnnotation, ArrowItem
 
@@ -32,8 +32,10 @@ class TestAnnotationItem(TestItems):
         annot.setPos(400, 100)
         annot.adjustSize()
         annot._TextAnnotation__textItem.setFocus()
+        annot3 = TextAnnotation(pos=QPointF(100, 100))
         self.scene.addItem(annot)
         self.scene.addItem(annot2)
+        self.scene.addItem(annot3)
         self.qWait()
 
     def test_arrowannotation(self):


### PR DESCRIPTION
### Issue

Creating a text annotation on the canvas raises an error on Python 3.10

```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange-canvas-core/orangecanvas/canvas/items/annotationitem.py", line 82, in paint
    text = metrics.elidedText(self.__placeholderText, Qt.ElideRight,
TypeError: elidedText(self, str, Qt.TextElideMode, int, flags: int = 0): argument 3 has unexpected type 'float'
-------------------------------------------------------------------------------
```

### Changes

Replace use of QFontMetrics with QFontMetricsF