### PR TITLE
[FIX] HtmlIndexProvider: fix path to work with docutils >= 0.17

### DIFF
--- a/orangecanvas/help/provider.py
+++ b/orangecanvas/help/provider.py
@@ -268,7 +268,9 @@ class HtmlIndexProvider(BaseInventoryProvider):
         parser.feed(stream)
         self.root = parser.builder.close()
 
-        path = self.xpathquery or ".//div[@id='widgets']//li/a"
+        # docutils < 0.17 use div tag, docutils >= 0.17 use section tags
+        # use * instead of explicit tag
+        path = self.xpathquery or ".//*[@id='widgets']//li/a"
 
         items = {}  # type: Dict[str, str]
         for el in self.root.findall(path):

--- a/orangecanvas/help/tests/test_provider.py
+++ b/orangecanvas/help/tests/test_provider.py
@@ -73,18 +73,19 @@ class TestHtmlIndexProvider(QCoreAppTestCase):
             b' <header>\n'
             b'   <meta charset=cp1252" />\n'
             b' </header>\n'
-            b' <body><div id="widgets">\n'
+            b' <body><%s id="widgets">\n'
             b'  <ul>\n'
             b'   <li><a href="a.html">aa</li>\n'
             b'  </ul>\n'
             b'  </div>\n'
             b'</html>'
         )
-        with temp_named_file(contents.decode("ascii"),) as fname:
-            url = QUrl.fromLocalFile(fname)
-            p = HtmlIndexProvider(url)
-            loop = get_event_loop()
-            desc = WidgetDescription(name="aa", id="aa", qualified_name="aa")
-            res = loop.run_until_complete(p.search_async(desc))
-            self.assertEqual(res, url.resolved(QUrl("a.html")))
-            self.assertEqual(p.items, {"aa": "a.html"})
+        for tag in (b"section", b"div"):
+            with temp_named_file((contents % tag).decode("ascii"),) as fname:
+                url = QUrl.fromLocalFile(fname)
+                p = HtmlIndexProvider(url)
+                loop = get_event_loop()
+                desc = WidgetDescription(name="aa", id="aa", qualified_name="aa")
+                res = loop.run_until_complete(p.search_async(desc))
+                self.assertEqual(res, url.resolved(QUrl("a.html")))
+                self.assertEqual(p.items, {"aa": "a.html"})


### PR DESCRIPTION
HtmlIndexProvider does not discover documentation build with docutils >= 0.17 because HTML format slight changed. They use section tag instead of div now for the section with a list of widgets.

Fix path to support both div and section tags