### PR TITLE
Fix failing ubuntu ci workers

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -101,7 +101,9 @@ jobs:
       - name: Install System Deps
         if: ${{ startsWith(runner.os, 'Linux') }}
         # https://www.riverbankcomputing.com/pipermail/pyqt/2020-June/042949.html
-        run: sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa
+        run: |
+          sudo apt-get update 
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa
 
       - name: Setup Pip Cache
         uses: actions/cache@v2


### PR DESCRIPTION
Ubuntu workers fail with:
```
Get:12 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libxcb-render-util0 amd64 0.3.9-1build1 [9912 B]
Fetched 117 kB in 1s (114 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_21.2.6-0ubuntu0.1~20.04.1_amd64.deb  [40](https://github.com/biolab/orange-canvas-core/runs/5596587010?check_suite_focus=true#step:4:40)4  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libg/libglvnd/libegl1_1.3.2-1~ubuntu0.20.04.1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/m/mesa/libegl1-mesa_21.2.6-0ubuntu0.1~20.04.1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Fix them with running update before install.