### PR TITLE
[FIX] application: Fix argparse type error

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -26,6 +26,14 @@ jobs:
             test-env: "PyQt5~=5.12.0"
 
           - os: ubuntu-20.04
+            python-version: 3.6
+            test-env: "PyQt5~=5.15.0"
+
+          - os: ubuntu-20.04
+            python-version: 3.7
+            test-env: "PyQt5~=5.15.0"
+
+          - os: ubuntu-20.04
             python-version: 3.8
             test-env: "PyQt5~=5.14.0"
 

--- a/orangecanvas/application/application.py
+++ b/orangecanvas/application/application.py
@@ -183,9 +183,13 @@ class CanvasApplication(QApplication):
                 os.environ.get("QT_SCALE_FACTOR_ROUNDING_POLICY"),
                 Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
             )
+
+            def converter(value):
+                # dict.get wrapper due to https://bugs.python.org/issue16516
+                return HighDpiScaleFactorRoundingPolicyLookup.get(value)
             parser.add_argument(
                 "-scale-factor-rounding-policy",
-                type=HighDpiScaleFactorRoundingPolicyLookup.get,
+                type=converter,
                 choices=[*HighDpiScaleFactorRoundingPolicyLookup.values(), None],
                 default=default,
             )

--- a/orangecanvas/application/tests/test_application.py
+++ b/orangecanvas/application/tests/test_application.py
@@ -23,6 +23,12 @@ class TestApplication(unittest.TestCase):
         ])
         self.assertEqual(res.returncode, 0)
 
+    def test_application_help(self):
+        res = sh.python_run([
+            "-m", "orangecanvas", "--help"
+        ])
+        self.assertEqual(res.returncode, 0)
+
 
 def remove_after_exit(fname):
     appmod.run_after_exit([


### PR DESCRIPTION
### Issue

Ref: https://github.com/biolab/orange3/discussions/5927

orange-canvas raises an error with Python <= 3.7 and PyQt5 >= 5.14  
```
...
  File "/root/DATA/orange_env/lib/python3.7/site-packages/orangecanvas/application/application.py", line 190, in argumentParser
    default=default,
  File "/usr/local/python3/lib/python3.7/argparse.py", line 1362, in add_argument
    type_func = self._registry_get('type', action.type, action.type)
  File "/usr/local/python3/lib/python3.7/argparse.py", line 1304, in _registry_get
    return self._registries[registry_name].get(value, default)
TypeError: unhashable type: 'dict'
```
This is due to https://bugs.python.org/issue16516

### Changes

Wrap a dict.get bound method in a function.
Add test configuration that would have caught this.
