### PR TITLE
[RFC][FIX] Log to file with utf-8 encoding

### DIFF
--- a/orangecanvas/main.py
+++ b/orangecanvas/main.py
@@ -452,7 +452,7 @@ def make_stream_handler(level, fileobj=None, fmt=None):
 
 
 def make_file_handler(level, filename, mode="w", fmt=None):
-    handler = logging.FileHandler(filename, mode=mode)
+    handler = logging.FileHandler(filename, mode=mode, encoding="utf-8")
     handler.setLevel(level)
     if fmt:
         handler.setFormatter(logging.Formatter(fmt))


### PR DESCRIPTION
#### Issue

Since orange canvas log to file in default encoding (Windows-1252 on Windows) it fails on logging some strings. For example, the following code in the python script fails:

```
import logging

s = "✌🏼️"
log = logging.getLogger("__name__")
log.warning(s)
```
with:
```
Traceback (most recent call last):
  File "C:\Users\biolab\AppData\Local\Programs\Orange\lib\logging\__init__.py", line 1084, in emit
    stream.write(msg + self.terminator)
  File "C:\Users\biolab\AppData\Local\Programs\Orange\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u010d' in position 55: character maps to <undefined>
```

#### Changes

Log in `utf-8` encoding. If I understand correctly it can write to file anything that can be encoded in a python string. Hope that I didn't miss any cases.

#### Note

It is not that I want to lag strange strings but one of the libraries that Orange3-text uses does. They log some tokens that come on the input. It failed with a valid string tokens from tweets (where some special characters are included - emoji).