### PR TITLE
[FIX] interactions: Iterate only over unique entry_points

### DIFF
--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -45,6 +45,7 @@ from ..canvas.items import controlpoints
 from ..gui.quickhelp import QuickHelpTipEvent
 from . import commands
 from .editlinksdialog import EditLinksDialog
+from ..utils import unique
 
 if typing.TYPE_CHECKING:
     from .schemeedit import SchemeEditWidget
@@ -2020,7 +2021,11 @@ class PluginDropHandler(DropHandler):
         """
         Return an iterator over all entry points.
         """
-        return entry_points().get(self.__group, [])
+        eps = entry_points().get(self.__group, [])
+        # Can have duplicated entries here if a distribution is *found* via
+        # different `sys.meta_path` handlers and/or on different `sys.path`
+        # entries.
+        return unique(eps, key=lambda ep: ep.value)
 
     __entryPoints = None
 


### PR DESCRIPTION
### Issue

The *canvas drop handlers* can sometimes have duplicated entries and present a selection menu. 

`entry_points()` can return duplicated entries when there are multiple `sys.meta_path` with `find_distributions()` defined, or if a same package is found in two different entries on `sys.path`

### Changes

Iterate only over unique entry_points