### PR TITLE
[FIX] Update necessary dependencies when installing addons (pip)

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1501,11 +1501,12 @@ class PipInstaller:
 
     def install(self, pkg):
         # type: (Installable) -> None
-        cmd = ["python", "-m", "pip",  "install"] + self.arguments
+        cmd = [
+            "python", "-m", "pip", "install", "--upgrade",
+            "--upgrade-strategy=only-if-needed",
+        ] + self.arguments
         if pkg.package_url.startswith(("http://", "https://")):
-            version = (
-                "=={}".format(pkg.version) if pkg.version is not None else ""
-            )
+            version = "=={}".format(pkg.version) if pkg.version is not None else ""
             cmd.append(pkg.name + version)
         else:
             # Package url is path to the (local) wheel


### PR DESCRIPTION
### Issue

When upgrading/installing an add-on that requires an orange3 update from the add-on dialogue, Orange's dependencies do not upgrade. For example:
- I have orange3==3.32
- I install orange3-text, which requires orange3==3.33
- Orange3 gets updated but not its dependencies (including orange-widget-base and orange-canvas-core)
- It caused Orange to stop working since Orange3 needs orange-canvas-core and widget-base versions higher than they ship with orange3==3.32

### Fix
Adding the `--upgrade` option to the `pip install` command will also update other dependencies if necessary (`only-if-needed` is pip's current default strategy)