### PR TITLE
[CI] Add Python 3.11 to test matrices

### DIFF
--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -19,14 +19,14 @@ jobs:
             python: 3.6
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
       - name: Setup Pip Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-docs-build.yml') }}

--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            python: 3.6
+            python: 3.7
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -18,16 +18,12 @@ jobs:
         include:
           # Linux
           - os: ubuntu-20.04
-            python-version: 3.6
+            python-version: 3.7
             test-env: "PyQt5~=5.9.2 qasync<0.19.0"
 
           - os: ubuntu-18.04
-            python-version: 3.7
+            python-version: 3.8
             test-env: "PyQt5~=5.12.0"
-
-          - os: ubuntu-20.04
-            python-version: 3.6
-            test-env: "PyQt5~=5.15.0"
 
           - os: ubuntu-20.04
             python-version: 3.7
@@ -35,70 +31,74 @@ jobs:
 
           - os: ubuntu-20.04
             python-version: 3.8
-            test-env: "PyQt5~=5.14.0"
+            test-env: "PyQt5~=5.15.0"
 
           - os: ubuntu-20.04
             python-version: 3.9
-            test-env: "PyQt5~=5.15.0"
+            test-env: "PyQt5~=5.14.0"
 
           - os: ubuntu-20.04
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0"
 
           - os: ubuntu-20.04
-            python-version: "3.10"
+            python-version: "3.11"
+            test-env: "PyQt5~=5.15.0"
+
+          - os: ubuntu-20.04
+            python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3"
 
           # macOS
           - os: macos-11
-            python-version: 3.7
+            python-version: 3.8
             test-env: "PyQt5~=5.12.0"
 
           - os: macos-11
-            python-version: 3.8
+            python-version: 3.9
             test-env: "PyQt5~=5.14.0"
 
           - os: macos-11
-            python-version: 3.9
-            test-env: "PyQt5~=5.15.0"
-
-          - os: macos-12
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0"
 
           - os: macos-12
-            python-version: "3.10"
+            python-version: "3.11"
+            test-env: "PyQt5~=5.15.0"
+
+          - os: macos-12
+            python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3"
 
           # Windows
           - os: windows-2019
-            python-version: 3.6
+            python-version: 3.7
             test-env: "PyQt5~=5.9.2"
 
           - os: windows-2019
-            python-version: 3.7
+            python-version: 3.8
             test-env: "PyQt5~=5.12.0"
 
           - os: windows-2019
-            python-version: 3.8
+            python-version: 3.9
             test-env: "PyQt5~=5.14.0"
 
           - os: windows-2019
-            python-version: 3.9
-            test-env: "PyQt5~=5.15.0"
-
-          - os: windows-2019
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0"
 
           - os: windows-2019
-            python-version: "3.10"
+            python-version: "3.11"
+            test-env: "PyQt5~=5.15.0"
+
+          - os: windows-2019
+            python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3"
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -81,7 +81,7 @@ jobs:
 
           - os: windows-2019
             python-version: 3.9
-            test-env: "PyQt5~=5.14.0"
+            test-env: "PyQt5~=5.15.0"
 
           - os: windows-2019
             python-version: "3.10"

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -96,9 +96,9 @@ jobs:
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -110,7 +110,7 @@ jobs:
           sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0
 
       - name: Setup Pip Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-tests-workflow.yml') }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-   version: "3.6"
+   version: "3.7"
    install:
       - requirements: docs/requirements-rtd.txt
       # no - method: pip here, -e . is already in docs/requirements-rtd.txt


### PR DESCRIPTION
### Changes

* Add Python 3.11 to test matrices
* Drop Python 3.6 from test matrices
* Update used gh actions to avoid runner deprecation warnings