### PR TITLE
[FIX] canvasmain: Handle errors trying to remove swp files

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1618,14 +1618,20 @@ class CanvasMainWindow(QMainWindow):
         document = self.current_document()
         path = document.path()
 
+        def remove(filename: str) -> None:
+            try:
+                os.remove(filename)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                log.warning("Could not delete swp file: %s", e)
+
         if path or self in canvas_scratch_name_memo:
-            swpname = swp_name(self)
-            if os.path.exists(swpname):
-                os.remove(swpname)
+            remove(swp_name(self))
         else:
             swpnames = glob_scratch_swps()
             for swpname in swpnames:
-                os.remove(swpname)
+                remove(swpname)
 
     def ask_load_swp_if_exists(self):
         """


### PR DESCRIPTION
### Issue

Clearing the *.swp* file can raise an error when e.g. a workflow with a swp file is loaded from a read only filesystem or belonging to a different user...

### Changes

Handle errors trying to remove .swp files