### PR TITLE
addons: list_available_versions continues with non-critical exceptions

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -1289,6 +1289,7 @@ def list_available_versions(config, session=None):
     try:
         defaults = config.addon_defaults_list()
     except requests.exceptions.RequestException as e:
+        defaults = []
         exceptions.append(e)
 
     def getname(item):


### PR DESCRIPTION
If there is a network problem in `list_available_versions`, the add-on dialog becomes useless. It could allow at least uninstallation.

I changed `list_available_versions` to continue on network errors and gathers whatever info it can, so that the dialog still works for some actions. The first exceptions is still displayed in a dialog as before.