### PR TITLE
Add function for English plural forms

### DIFF
--- a/orangecanvas/utils/localization/__init__.py
+++ b/orangecanvas/utils/localization/__init__.py
@@ -1,0 +1,31 @@
+def pl(n: int, forms: str) -> str:  # pylint: disable=invalid-name
+    """
+    Choose a singular/plural form for English - or create one, for regular nouns
+
+    `forms` can be a string containing the singular and plural form, separated
+    by "|", for instance `pl(n, "leaf|leaves")`.
+
+    For nouns that are formed by adding an -s (e.g. tree -> trees),
+    and for nouns that end with -y that is replaced by -ies
+    (dictionary -> dictionaries), it suffices to pass the noun,
+    e.g. `pl(n, "tree")`, `pl(n, "dictionary")`.
+
+    Args:
+        n: number
+        forms: plural forms, separated by "|", or a single (regular) noun
+
+    Returns:
+        form corresponding to the given number
+    """
+    plural = int(n != 1)
+
+    if "|" in forms:
+        return forms.split("|")[plural]
+
+    if forms[-1] in "yY" and forms[-2] not in "aeiouAEIOU":
+        word = [forms, forms[:-1] + "ies"][plural]
+    else:
+        word = forms + "s" * plural
+    if forms.isupper():
+        word = word.upper()
+    return word

--- a/orangecanvas/utils/localization/tests/test_localization.py
+++ b/orangecanvas/utils/localization/tests/test_localization.py
@@ -1,0 +1,21 @@
+import unittest
+
+from orangecanvas.utils.localization import pl
+
+
+class TestLocalization(unittest.TestCase):
+    def test_pl(self):
+        for forms, singular, plural in (("word", "word", "words"),
+                                        ("sun" , "sun", "suns"),
+                                        ("day", "day", "days"),
+                                        ("FEE", "FEE", "FEES"),
+                                        ("daisy", "daisy", "daisies"),
+                                        ("FEY", "FEY", "FEYS"),
+                                        ("leaf|leaves", "leaf", "leaves")):
+            self.assertEqual(pl(1, forms), singular)
+            for n in (2, 5, 101, -1):
+                self.assertEqual(pl(n, forms), plural, msg=f"for n={n}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
To be used here and also in dependent projects (orange-widget-base, orange3, add-ons).

The function is not in module (i.e. file localization.py) but in package, so that we have a place where translations to other languages can drop modules with their specific functions.