### PR TITLE
[FIX] provider: Remove use of obsolete FollowRedirectsAttribute

### DIFF
--- a/orangecanvas/help/provider.py
+++ b/orangecanvas/help/provider.py
@@ -87,9 +87,6 @@ class BaseInventoryProvider(HelpProvider):
                 QNetworkRequest.PreferCache
             )
             req.setAttribute(
-                QNetworkRequest.FollowRedirectsAttribute, True
-            )
-            req.setAttribute(
                 QNetworkRequest.RedirectPolicyAttribute,
                 QNetworkRequest.NoLessSafeRedirectPolicy
             )


### PR DESCRIPTION
### Issue

Fixes https://github.com/biolab/orange-canvas-core/issues/250

### Changes

Remove use of obsolete FollowRedirectsAttribute. setting RedirectPolicyAttribute already does the job.