### PR TITLE
[FIX] process_qss: Fix prefix path extraction regex

### DIFF
--- a/orangecanvas/styles/__init__.py
+++ b/orangecanvas/styles/__init__.py
@@ -140,7 +140,7 @@ def style_sheet(stylesheet: str) -> Tuple[str, List[Tuple[str, str]]]:
     """
     def process_qss(content: str, base: str):
         pattern = re.compile(
-            r"^\s@([a-zA-Z0-9_]+?)\s*:\s*([a-zA-Z0-9_/]+?);\s*$",
+            r"^\s*@([a-zA-Z0-9_]+?)\s*:\s*([a-zA-Z0-9_/]+?);\s*$",
             flags=re.MULTILINE
         )
         matches = pattern.findall(content)


### PR DESCRIPTION
### Issue

When running from a git checkout on windows with git autocrlf set to true there are 
warnings printed on the console about missing .Dropdown.svg icon file.

### Changes

Fix prefix path extraction regex.