### PR TITLE
[FIX] Menu window list fixups

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -712,13 +712,6 @@ class CanvasMainWindow(QMainWindow):
         sep.setObjectName("view-zoom-actions-separator")
 
         self.view_menu.addAction(self.toogle_margins_action)
-        raise_widgets_action = self.scheme_widget.findChild(
-            QAction, "bring-widgets-to-front-action"
-        )
-        if raise_widgets_action is not None:
-            self.view_menu.addAction(raise_widgets_action)
-
-        self.view_menu.addAction(self.float_widgets_on_top_action)
         menu_bar.addMenu(self.view_menu)
 
         # Options menu
@@ -737,6 +730,14 @@ class CanvasMainWindow(QMainWindow):
         )
         self.window_menu.addAction(self.minimize_action)
         self.window_menu.addAction(self.zoom_action)
+        self.window_menu.addSeparator()
+        raise_widgets_action = self.scheme_widget.findChild(
+            QAction, "bring-widgets-to-front-action"
+        )
+        if raise_widgets_action is not None:
+            self.window_menu.addAction(raise_widgets_action)
+
+        self.window_menu.addAction(self.float_widgets_on_top_action)
         menu_bar.addMenu(self.window_menu)
         menu_bar.addMenu(self.options_menu)
 

--- a/orangecanvas/gui/windowlistmanager.py
+++ b/orangecanvas/gui/windowlistmanager.py
@@ -95,9 +95,12 @@ class WindowListManager(QObject):
             if not state:
                 return
             handle: QWidget = action.data()
-            handle.show()
-            handle.raise_()
-            handle.activateWindow()
+            handle.setVisible(True)
+            if handle != QApplication.activeWindow():
+                # Do not re-activate when called from `focusWindowChanged`;
+                # breaks macOS window cycling (CMD+`) order.
+                handle.raise_()
+                handle.activateWindow()
 
         action.toggled.connect(activate)
         return action


### PR DESCRIPTION
### Issue

Since gh-248 <kbd>CMD+`</kbd> shortcut on macOS does not work properly.
Also the 'Raise Ancestors/Descendants' actions inserted into the widgets should be disabled when non applicable (i.e. have no ancestors/descendants)

### Changes

* Do not double activate a window on<kbd>CMD+`</kbd>
* Enable/disable 'Raise Ancestors/Descendants' actions
* Also move 'Bring Widgets to Front' and 'Display Widgets on Top' to 'Windows' menu.

