### PR TITLE
Workflow zoom-in also works with Ctrl+= (forgotten shift)

### DIFF
--- a/orangecanvas/canvas/view.py
+++ b/orangecanvas/canvas/view.py
@@ -39,10 +39,13 @@ class CanvasView(QGraphicsView):
 
         self.__zoomInAction = QAction(
             self.tr("Zoom in"), self, objectName="action-zoom-in",
-            shortcut=QKeySequence.ZoomIn,
             triggered=self.zoomIn,
         )
-
+        ctrl = "Cmd" if sys.platform == "darwin" else "Ctrl"
+        self.__zoomInAction.setShortcuts([
+            QKeySequence.ZoomIn,
+            QKeySequence(ctrl + "+=")]  # if users forget to press Shift on us keyboards
+        )
         self.__zoomOutAction = QAction(
             self.tr("Zoom out"), self, objectName="action-zoom-out",
             shortcut=QKeySequence.ZoomOut,


### PR DESCRIPTION
Modern browsers allow zooming in without pressing shift on US keyboard (`Ctrl + +` is actually `Ctrl + Shift + =). So we are spoiled.

Qt's docs actually warn about this specific case (and they recommend caution): https://doc.qt.io/qt-5/qkeysequence.html#keyboard-layout-issues

I do not see any problems with allowing `Ctrl + =` too (do we use it anywhere else?). It does make the code slightly uglier. 

If accepted, this fixes biolab/orange3#6240.