### PR TITLE
[FIX] Set default application level window icon

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -810,8 +810,21 @@ class CanvasMainWindow(QMainWindow):
             self.setWindowTitle(self.tr("Untitled [*]"))
 
     def setWindowFilePath(self, filePath):  # type: (str) -> None
+        def icon_for_path(path: str) -> 'QIcon':
+            iconprovider = QFileIconProvider()
+            finfo = QFileInfo(path)
+            if finfo.exists():
+                return iconprovider.icon(finfo)
+            else:
+                return iconprovider.icon(QFileIconProvider.File)
+
         if sys.platform == "darwin":
             super().setWindowFilePath(filePath)
+            # If QApplication.windowIcon() is not null then it is used instead
+            # of the file type specific one. This is wrong so we set it
+            # explicitly.
+            if not QApplication.windowIcon().isNull() and filePath:
+                self.setWindowIcon(icon_for_path(filePath))
         else:
             # use non-empty path to 'force' Qt to add '[*]' modified marker
             # in the displayed title.

--- a/orangecanvas/main.py
+++ b/orangecanvas/main.py
@@ -175,6 +175,7 @@ class Main:
     def setup_application(self):
         # sys.argv[0] must be in QApplication's argv list.
         self.application = CanvasApplication(sys.argv[:1] + self.arguments)
+        self.application.setWindowIcon(self.config.application_icon())
         # Update the arguments
         self.arguments = self.application.arguments()[1:]
         fix_set_proxy_env()


### PR DESCRIPTION
### Issue

Orange installed from conda/pip does not have an icon (on Mac) 

Fixes: https://github.com/biolab/orange3/issues/6129

### Changes

Set default application level window icon (special care must be taken so the default application icon does not override the "proxy icon" for file in the main window).