### PR TITLE
Refer to channels by ids, not their visible names when saving/loading

### DIFF
--- a/orangecanvas/registry/base.py
+++ b/orangecanvas/registry/base.py
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # Registry hex version
-VERSION_HEX = 0x000105
+VERSION_HEX = 0x000106
 
 
 class WidgetRegistry(object):

--- a/orangecanvas/registry/tests/__init__.py
+++ b/orangecanvas/registry/tests/__init__.py
@@ -135,7 +135,7 @@ def small_testing_registry():
         "zero", "zero", "Constants",
         qualified_name="zero",
         package=__package__,
-        outputs=[OutputSignal("value", "int")])
+        outputs=[OutputSignal("value", "int", id="val")])
 
     one = WidgetDescription(
         "one", "one", "Constants",
@@ -157,7 +157,7 @@ def small_testing_registry():
         qualified_name="add",
         package=__package__,
         inputs=[InputSignal("left", "int", "set_left"),
-                InputSignal("right", "int", "set_right")],
+                InputSignal("right", "int", "set_right", id="droite")],
         outputs=[OutputSignal("result", "int")]
     )
     sub = WidgetDescription(

--- a/orangecanvas/scheme/node.py
+++ b/orangecanvas/scheme/node.py
@@ -134,9 +134,13 @@ class SchemeNode(QObject):
         if not found.
         """
         for channel in self.input_channels():
+            if channel.id == name:
+                return channel
+        # Fallback to channel names for backward compatibility
+        for channel in self.input_channels():
             if channel.name == name:
                 return channel
-        raise ValueError("%r is not a valid input channel name for %r." % \
+        raise ValueError("%r is not a valid input channel for %r." % \
                          (name, self.description.name))
 
     def output_channel(self, name):
@@ -146,9 +150,13 @@ class SchemeNode(QObject):
         if not found.
         """
         for channel in self.output_channels():
+            if channel.id == name:
+                return channel
+        # Fallback to channel names for backward compatibility
+        for channel in self.output_channels():
             if channel.name == name:
                 return channel
-        raise ValueError("%r is not a valid output channel name for %r." % \
+        raise ValueError("%r is not a valid output channel for %r." % \
                          (name, self.description.name))
 
     #: The title of the node has changed

--- a/orangecanvas/scheme/readwrite.py
+++ b/orangecanvas/scheme/readwrite.py
@@ -552,8 +552,11 @@ def scheme_to_etree(scheme, data_format="literal", pickle_fallback=False):
         attrs = {"id": str(link_ids[link]),
                  "source_node_id": str(source_id),
                  "sink_node_id": str(sink_id),
-                 "source_channel": link.source_channel.name,
-                 "sink_channel": link.sink_channel.name,
+                 # Use channel ids; fallback to name for backward compatibility
+                 "source_channel":
+                     link.source_channel.id or link.source_channel.name,
+                 "sink_channel":
+                     link.sink_channel.id or link.sink_channel.name,
                  "enabled": "true" if link.enabled else "false",
                  }
         builder.start("link", attrs)

--- a/orangecanvas/scheme/tests/test_nodes.py
+++ b/orangecanvas/scheme/tests/test_nodes.py
@@ -32,3 +32,18 @@ class TestScheme(test.QAppTestCase):
             self.assertIsInstance(channel, OutputSignal)
             self.assertTrue(channel in outputs)
         self.assertRaises(ValueError, node.output_channel, "%%&&&$$()[()[")
+
+    def test_channels_by_name_or_id(self):
+        reg = small_testing_registry()
+
+        zero_desc = reg.widget("zero")
+        node = SchemeNode(zero_desc)
+        self.assertIs(node.output_channel("value"), zero_desc.outputs[0])
+        self.assertIs(node.output_channel("val"), zero_desc.outputs[0])
+
+        add_desc = reg.widget("add")
+        node = SchemeNode(add_desc)
+        self.assertIs(node.input_channel("left"), add_desc.inputs[0])
+        self.assertIs(node.input_channel("right"), add_desc.inputs[1])
+        self.assertIs(node.input_channel("droite"), add_desc.inputs[1])
+        self.assertRaises(ValueError, node.input_channel, "gauche")


### PR DESCRIPTION
Channels have names (for humans) and ids (for machines).

A workflow created in English version of Orange cannot be loaded in Slovenian Orange because channel names are translated. This change fixes that by using id's, which are not translated. This change will have effect after https://github.com/biolab/orange-widget-base/pull/229 is merged.

I think using id's in .ows is also better in principle.

For backward compatibility, `input_channel` and `output_channel` match by id and, as a fallback, by name. This will fail if id is the same as the name of another signal, which is unlikely. Besides, https://github.com/biolab/orange-widget-base/pull/229 shows a warning in such cases.