### PR TITLE
Category discovery: Improve logic for determining category name

### DIFF
--- a/orangecanvas/registry/discovery.py
+++ b/orangecanvas/registry/discovery.py
@@ -46,6 +46,16 @@ _CacheEntry = \
     )
 
 
+def default_category_name_for_module(module):
+    if isinstance(module, str):
+        module = __import__(module, fromlist=[""])
+    path = module.__name__.split(".")
+    name = path[-1]
+    if name == "widgets" and len(path) > 1:
+        name = path[-2].capitalize()
+    return name
+
+
 def default_category_for_module(module):
     """
     Return a default constructed :class:`CategoryDescription`
@@ -54,7 +64,7 @@ def default_category_for_module(module):
     """
     if isinstance(module, str):
         module = __import__(module, fromlist=[""])
-    name = module.__name__.rsplit(".", 1)[-1]
+    name = default_category_name_for_module(module)
     qualified_name = module.__name__
     return CategoryDescription(name=name, qualified_name=qualified_name)
 
@@ -202,8 +212,11 @@ class WidgetDiscovery(object):
                          exc_info=True)
                 cat_desc = default_category_for_module(category)
 
-        if name is not None:
-            cat_desc.name = name
+        if cat_desc.name is None:
+            if name is not None:
+                cat_desc.name = name
+            else:
+                cat_desc.name = default_category_name_for_module(category)
 
         if distribution is not None:
             cat_desc.project_name = distribution.project_name

--- a/orangecanvas/registry/utils.py
+++ b/orangecanvas/registry/utils.py
@@ -122,9 +122,8 @@ def category_from_package_globals(package):
 
     package_name = package.__name__
     qualified_name = package_name
-    default_name = package_name.rsplit(".", 1)[-1]
 
-    name = getattr(package, "NAME", default_name)
+    name = getattr(package, "NAME", None)
     description = getattr(package, "DESCRIPTION", None)
     long_description = getattr(package, "LONG_DESCRIPTION", None)
     author = getattr(package, "AUTHOR", None)
@@ -140,7 +139,8 @@ def category_from_package_globals(package):
     background = getattr(package, "BACKGROUND", None)
     hidden = getattr(package, "HIDDEN", None)
 
-    if priority == sys.maxsize - 1 and name.lower() == "prototypes":
+    if priority == sys.maxsize - 1 \
+            and name is not None and name.lower() == "prototypes":
         priority = sys.maxsize
 
     return CategoryDescription(


### PR DESCRIPTION
This PR changes the resolving the category name to follow this order,

- `NAME` from package globals,
- entry point from setup.py,
- the name deduced from qualified package name. This used to take the last part, but this is usually `"widgets"`. Now it takes the penultimate part in that case.

Previously, the first two points were reversed. I think package globals should have precedence because they are explicit.

Besides, the entry point is always defined (has to be, AFAIK), so the name from package globals was ignored. As result, we couldn't translate category names.

