### PR TITLE
[ENH] editlinksdialog: Replace hardcoded colors with palette derived ones

### DIFF
--- a/orangecanvas/document/tests/test_editlinksdialog.py
+++ b/orangecanvas/document/tests/test_editlinksdialog.py
@@ -1,3 +1,4 @@
+from AnyQt.QtGui import QPalette
 from AnyQt.QtWidgets import QGraphicsScene, QGraphicsView
 from AnyQt.QtCore import Qt, QPoint
 
@@ -5,7 +6,7 @@ from ...utils import findf
 from ...registry.tests import small_testing_registry
 from ...gui import test
 from ..editlinksdialog import EditLinksDialog, EditLinksNode, \
-    GraphicsTextWidget, LinksEditWidget, LinkLineItem
+    GraphicsTextWidget, LinksEditWidget, LinkLineItem, ChannelAnchor
 from ...scheme import SchemeNode
 
 
@@ -83,6 +84,22 @@ class TestLinksEditDialog(test.QAppTestCase):
         test.mouseMove(view.viewport(), Qt.NoButton, pos=pos)  # hover over line
         view.grab()  # paint in hovered state
         test.mouseMove(view.viewport(), Qt.NoButton, pos=QPoint(0, 0)) # hover leave
+
+        palette = QPalette()
+        palette.setColor(QPalette.Text, Qt.red)
+        widget.setPalette(palette)
+        view.grab()
+
+        anchor = findf(widget.sourceNodeWidget.childItems(),
+                       lambda item: isinstance(item, ChannelAnchor))
+        pos = view.mapFromScene(anchor.mapToScene(anchor.rect().center()))
+
+        test.mouseMove(view.viewport(), Qt.NoButton, pos=pos)  # hover over anchor
+        view.grab()  # paint in hovered state
+        test.mouseMove(view.viewport(), Qt.NoButton, pos=QPoint(0, 0))  # hover leave
+
+        anchor.setEnabled(False)
+        view.grab()  # paint in disabled state
 
 
 class TestGraphicsTextWidget(test.QAppTestCase):


### PR DESCRIPTION
### Issue

The Edit Links dialog has bad contrast with dark style.

### Changes

Replace hardcoded colors with palette derived ones.

Before:
![Screenshot_20230503_123350](https://user-images.githubusercontent.com/4716745/236192366-3a46753d-f9a7-43bd-ac20-464915b86fde.png)
After:
![Screenshot_20230503_123456](https://user-images.githubusercontent.com/4716745/236192391-7a6c23b7-6a3a-4930-8723-7405018fe9df.png)

