### PR TITLE
[ENH] Color styled widget icons

### DIFF
--- a/orangecanvas/application/application.py
+++ b/orangecanvas/application/application.py
@@ -9,6 +9,7 @@ from typing import Optional, List, Sequence
 
 import AnyQt
 from AnyQt.QtWidgets import QApplication
+from AnyQt.QtGui import QPixmapCache
 from AnyQt.QtCore import (
     Qt, QUrl, QEvent, QSettings, QLibraryInfo, pyqtSignal as Signal,
     QT_VERSION_INFO
@@ -231,6 +232,7 @@ class CanvasApplication(QApplication):
         if theme and theme in styles.colorthemes:
             palette = styles.colorthemes[theme]()
             QApplication.setPalette(palette)
+        QPixmapCache.setCacheLimit(64 * (2 ** 10))
 
 
 __restart_command: Optional[List[str]] = None

--- a/orangecanvas/application/widgettoolbox.py
+++ b/orangecanvas/application/widgettoolbox.py
@@ -25,7 +25,7 @@ from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 from ..gui.toolbox import ToolBox
 from ..gui.toolgrid import ToolGrid
 from ..gui.quickhelp import StatusTipPromoter
-from ..gui.utils import create_gradient
+from ..gui.utils import create_gradient_brush
 from ..registry.qt import QtWidgetRegistry
 
 
@@ -425,8 +425,7 @@ class WidgetToolBox(ToolBox):
         if isinstance(highlight, QBrush) and highlight.style() != Qt.NoBrush:
             if not highlight.gradient():
                 value = highlight.color().value()
-                gradient = create_gradient(highlight.color())
-                highlight = QBrush(gradient)
+                highlight = create_gradient_brush(highlight.color())
                 highlight_foreground = Qt.black if value > 128 else Qt.white
 
         palette = button.palette()

--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -37,6 +37,8 @@ from .graphicstextitem import GraphicsTextItem, GraphicsTextEdit
 from .utils import (
     saturated, radial_gradient, linspace, qpainterpath_sub_path, clip
 )
+from ... import styles
+from ...gui.iconengine import StyledIconEngine
 from ...gui.utils import disconnected
 
 from ...scheme.node import UserMessage
@@ -1152,7 +1154,10 @@ class GraphicsIconItem(QGraphicsWidget):
                 QPainter.SmoothPixmapTransform,
                 self.__transformationMode == Qt.SmoothTransformation
             )
-            self.__icon.paint(painter, target, Qt.AlignCenter, mode)
+            palette = self.palette()
+            # assuming light-ish background color
+            with StyledIconEngine.setOverridePalette(palette):
+                self.__icon.paint(painter, target, Qt.AlignCenter, mode)
 
 
 class NodeItem(QGraphicsWidget):
@@ -1335,6 +1340,8 @@ class NodeItem(QGraphicsWidget):
         self.icon_item = GraphicsIconItem(
             self.shapeItem, icon=icon, iconSize=QSize(36, 36)
         )
+        # assuming light-ish color background
+        self.icon_item.setPalette(styles.breeze_light())
         self.icon_item.setPos(-18, -18)
 
     def setColor(self, color, selectedColor=None):

--- a/orangecanvas/document/quickmenu.py
+++ b/orangecanvas/document/quickmenu.py
@@ -35,8 +35,10 @@ from AnyQt.QtCore import (
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 
 from .usagestatistics import UsageStatistics
+from .. import styles
 from ..gui.framelesswindow import FramelessWindow
 from ..gui.lineedit import LineEdit
+from ..gui.iconengine import StyledIconEngine
 from ..gui.tooltree import ToolTree, FlattenedTreeItemModel
 from ..gui.utils import StyledWidget_paintEvent, innerGlowBackgroundPixmap, innerShadowPixmap
 from ..registry.qt import QtWidgetRegistry
@@ -90,7 +92,8 @@ class _MenuItemDelegate(QStyledItemDelegate):
         decRect = QRectF(decTl, decBr)
 
         # draw icon pixmap
-        dec.paint(painter, decRect.toAlignedRect())
+        with StyledIconEngine.setOverridePalette(styles.breeze_light()):
+            dec.paint(painter, decRect.toAlignedRect())
 
         # draw display
         rect = QRect(opt.rect)
@@ -697,15 +700,16 @@ class TabButton(QToolButton):
         self.initStyleOption(opt)
         if self.__showMenuIndicator and self.isChecked():
             opt.features |= QStyleOptionToolButton.HasMenu
-        if self.__flat:
-            # Use default widget background/border styling.
-            StyledWidget_paintEvent(self, event)
+        with StyledIconEngine.setOverridePalette(styles.breeze_light()):
+            if self.__flat:
+                # Use default widget background/border styling.
+                StyledWidget_paintEvent(self, event)
 
-            p = QStylePainter(self)
-            p.drawControl(QStyle.CE_ToolButtonLabel, opt)
-        else:
-            p = QStylePainter(self)
-            p.drawComplexControl(QStyle.CC_ToolButton, opt)
+                p = QStylePainter(self)
+                p.drawControl(QStyle.CE_ToolButtonLabel, opt)
+            else:
+                p = QStylePainter(self)
+                p.drawComplexControl(QStyle.CC_ToolButton, opt)
 
         # if checked, no shadow
         if self.isChecked():

--- a/orangecanvas/gui/iconengine.py
+++ b/orangecanvas/gui/iconengine.py
@@ -1,0 +1,154 @@
+from itertools import count
+from contextlib import contextmanager
+from typing import Optional
+
+from AnyQt.QtCore import QObject, QSize, QRect
+from AnyQt.QtGui import (
+    QIconEngine, QPalette, QIcon, QPixmap, QPixmapCache, QImage, QPainter
+)
+from AnyQt.QtWidgets import QApplication, QStyleOption
+
+from orangecanvas.gui.utils import luminance
+from orangecanvas.utils.image import grayscale_invert
+
+__all__ = [
+    "StyledIconEngine",
+    "SymbolIconEngine",
+]
+
+
+_cache_id_gen = count()
+
+
+class StyledIconEngine(QIconEngine):
+    """
+    An abstract base class for icon engines that adapt to effective palette.
+    """
+    __slots__ = ("__palette", "__styleObject")
+
+    def __init__(self, *args, palette: Optional[QPalette] = None,
+                 styleObject: Optional[QObject] = None, **kwargs):
+        self.__palette = QPalette(palette) if palette is not None else None
+        self.__styleObject = styleObject
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def paletteFromStyleObject(obj: QObject) -> Optional[QPalette]:
+        palette = obj.property("palette")
+        if isinstance(palette, QPalette):
+            return palette
+        else:
+            return None
+
+    __paletteOverride = None
+
+    @staticmethod
+    @contextmanager
+    def setOverridePalette(palette: QPalette):
+        """
+        Temporarily override used QApplication.palette() with this class.
+
+        This can be used when the icon is drawn on a non default background
+        and as such might not contrast with it when using the default palette,
+        and neither paint device nor styleObject can be used for this.
+        """
+        old = StyledIconEngine.__paletteOverride
+        try:
+            StyledIconEngine.__paletteOverride = palette
+            yield
+        finally:
+            StyledIconEngine.__paletteOverride = old
+
+    @staticmethod
+    def paletteOverride() -> Optional[QPalette]:
+        return StyledIconEngine.__paletteOverride
+
+    def effectivePalette(self) -> QPalette:
+        if StyledIconEngine.__paletteOverride is not None:
+            return StyledIconEngine.__paletteOverride
+        if self.__palette is not None:
+            return self.__palette
+        elif self.__styleObject is not None:
+            palette = self.paletteFromStyleObject(self.__styleObject)
+            if palette is not None:
+                return palette
+        return QApplication.palette()
+
+
+# shorthands for eliminating runtime attr load in hot path
+_QIcon_Active_Modes = (QIcon.Active, QIcon.Selected)
+_QIcon_Disabled = QIcon.Disabled
+
+_QPalette_Active = QPalette.Active
+_QPalette_WindowText = QPalette.WindowText
+_QPalette_Disabled = QPalette.Disabled
+_QPalette_HighlightedText = QPalette.HighlightedText
+
+
+class SymbolIconEngine(StyledIconEngine):
+    """
+    A *Symbolic* icon engine adapter for turning simple grayscale base icon
+    to current effective appearance.
+
+    Arguments
+    ---------
+    base: QIcon
+        The base icon.
+    """
+    def __init__(self, base: QIcon):
+        super().__init__()
+        self.__base = QIcon(base)
+        self.__cache_key = next(_cache_id_gen)
+
+    def paint(
+            self, painter: QPainter, rect: QRect, mode: QIcon.Mode,
+            state: QIcon.State
+    ) -> None:
+        if not self.__base.isNull():
+            palette = self.effectivePalette()
+            size = rect.size()
+            dpr = painter.device().devicePixelRatioF()
+            size = size * dpr
+            pm = self.__renderStyledPixmap(size, mode, state, palette)
+            painter.drawPixmap(rect, pm)
+
+    def pixmap(self, size: QSize, mode: QIcon.Mode, state: QIcon.State) -> QPixmap:
+        return self.__renderStyledPixmap(size, mode, state, self.effectivePalette())
+
+    def __renderStyledPixmap(
+            self, size: QSize, mode: QIcon.Mode, state: QIcon.State,
+            palette: QPalette
+    ) -> QPixmap:
+        active = mode in _QIcon_Active_Modes
+        disabled = mode == _QIcon_Disabled
+        cg = _QPalette_Disabled if disabled else _QPalette_Active
+        role = _QPalette_WindowText if active else _QPalette_HighlightedText
+        namespace = f"{__name__}:SymbolIconEngine/{self.__cache_key}"
+        cachekey = f"{size.width()}x{size.height()}"
+        style_key = f"{hex(palette.cacheKey())}-{cg}-{role}"
+        pmcachekey = f"{namespace}/{cachekey}/{style_key}"
+        pm = QPixmapCache.find(pmcachekey)
+        if pm is None or pm.isNull():
+            color = palette.color(QPalette.Text)
+            src = self.__base.pixmap(size, mode, state)
+            src = src.toImage().convertToFormat(QImage.Format_ARGB32_Premultiplied)
+            if luminance(color) > 0.5:
+                dest = grayscale_invert(
+                    src,
+                    palette.color(QPalette.Text),
+                    palette.color(QPalette.Base),
+                )
+            else:
+                dest = src
+            pm = QPixmap.fromImage(dest)
+            QPixmapCache.insert(pmcachekey, pm)
+
+        self.__style = style = QApplication.style()
+        if style is not None:
+            opt = QStyleOption()
+            opt.palette = palette
+            pm = style.generatedIconPixmap(mode, pm, opt)
+        return pm
+
+    def clone(self) -> 'QIconEngine':
+        return SymbolIconEngine(self.__base)

--- a/orangecanvas/gui/svgiconengine.py
+++ b/orangecanvas/gui/svgiconengine.py
@@ -232,7 +232,7 @@ TEMPLATE = """
 """
 
 
-def _hexrgb_solid(color: QColor) -> str:
+def _hexrgb_solid(color: QColor, contrast: QColor = None) -> str:
     """
     Return a #RRGGBB color string from color. If color has alpha component
     multipy the color components with alpha to get a solid color.
@@ -242,7 +242,8 @@ def _hexrgb_solid(color: QColor) -> str:
     # (in hex or rgba syntax) so we pre-multiply with alpha to get solid
     # gray scale.
     if color.alpha() != 255:
-        contrast = QColor(Qt.black) if luminance(color) > 0.5 else QColor(Qt.white)
+        if contrast is None:
+            contrast = QColor(Qt.black) if luminance(color) > 0.5 else QColor(Qt.white)
         color = merged_color(color, contrast, color.alphaF())
     return color.name(QColor.HexRgb)
 
@@ -256,10 +257,11 @@ def render_svg_color_scheme_css(palette: QPalette, state: QIcon.State) -> str:
     complement = QColor(Qt.white) if lum > 0.5 else QColor(Qt.black)
     contrast = QColor(Qt.black) if lum > 0.5 else QColor(Qt.white)
     return TEMPLATE.format(
-        text=_hexrgb_solid(palette.color(text)),
+        text=_hexrgb_solid(palette.color(text), palette.color(background)),
         background=_hexrgb_solid(palette.color(background)),
         highlight=_hexrgb_solid(palette.color(hligh)),
-        disabled_text=_hexrgb_solid(palette.color(QPalette.Disabled, text)),
+        disabled_text=_hexrgb_solid(palette.color(QPalette.Disabled, text),
+                                    palette.color(QPalette.Disabled, background)),
         contrast=_hexrgb_solid(contrast),
         complement=_hexrgb_solid(complement),
     )

--- a/orangecanvas/gui/svgiconengine.py
+++ b/orangecanvas/gui/svgiconengine.py
@@ -1,6 +1,4 @@
 import io
-from contextlib import contextmanager
-
 from typing import IO, Optional
 
 from itertools import count
@@ -9,10 +7,10 @@ from xml.sax import make_parser, handler, saxutils
 from AnyQt.QtCore import Qt, QSize, QRect, QRectF, QObject
 from AnyQt.QtGui import (
     QIconEngine, QIcon, QPixmap, QPainter, QPixmapCache, QPalette, QColor,
-    QPaintDevice
 )
 from AnyQt.QtSvg import QSvgRenderer
 from AnyQt.QtWidgets import QStyleOption, QApplication
+from .iconengine import StyledIconEngine
 
 from .utils import luminance, merged_color
 
@@ -21,7 +19,7 @@ _cache_id_gen = count()
 
 class SvgIconEngine(QIconEngine):
     """
-    An svg icon engine reimplementation drawing from in-memory svg contents.
+    A svg icon engine reimplementation drawing from in-memory svg contents.
 
     Arguments
     ---------
@@ -100,11 +98,11 @@ _QIcon_Active_Modes = (QIcon.Active, QIcon.Selected)
 _Qt_KeepAspectRatio = Qt.KeepAspectRatio
 
 
-class StyledSvgIconEngine(QIconEngine):
+class StyledSvgIconEngine(StyledIconEngine):
     """
     A basic styled icon engine based on a QPalette colors.
 
-    This engine can draw css styled svg icons of specific format so as to
+    This engine can draw css styled svg icons of specific format to
     conform to the current color scheme based on effective `QPalette`.
 
     (Loosely based on KDE's KIconLoader)
@@ -123,8 +121,8 @@ class StyledSvgIconEngine(QIconEngine):
     `QApplication.palette` is used.
     """
     __slots__ = (
-        "__contents", "__styled_contents_cache", "__palette", "__renderer",
-        "__cache_key", "__style_object",
+        "__contents", "__styled_contents_cache", "__renderer",
+        "__cache_key",
     )
 
     def __init__(
@@ -134,7 +132,7 @@ class StyledSvgIconEngine(QIconEngine):
             palette: Optional[QPalette] = None,
             styleObject: Optional[QObject] = None,
     ) -> None:
-        super().__init__()
+        super().__init__(palette=palette, styleObject=styleObject)
         self.__contents = contents
         self.__styled_contents_cache = {}
         if palette is not None and styleObject is not None:
@@ -144,56 +142,19 @@ class StyledSvgIconEngine(QIconEngine):
         self.__cache_key = next(_cache_id_gen)
         self.__style_object = styleObject
 
-    @staticmethod
-    def __paletteFromPaintDevice(dev: QPaintDevice) -> Optional[QPalette]:
-        if isinstance(dev, QObject):
-            palette_ = dev.property("palette")
-            if isinstance(palette_, QPalette):
-                return palette_
-        return None
-
-    @staticmethod
-    def __paletteFromStyleObject(obj: QObject) -> Optional[QPalette]:
-        palette = obj.property("palette")
-        if isinstance(palette, QPalette):
-            return palette
-        else:
-            return None
-
     def paint(self, painter, rect, mode, state):
         # type: (QPainter, QRect, QIcon.Mode, QIcon.State) -> None
         if self.__renderer.isValid():
-            if self.__paletteOverride is not None:
-                palette = self.__paletteOverride
-            elif self.__palette is None:
-                palette = self.__paletteFromPaintDevice(painter.device())
-                if palette is None:
-                    palette = self._palette()
-            else:
-                palette = self._palette()
+            palette = self.effectivePalette()
             size = rect.size()
             dpr = painter.device().devicePixelRatioF()
             size = size * dpr
             pm = self.__renderStyledPixmap(size, mode, state, palette)
             painter.drawPixmap(rect, pm)
 
-    def _palette(self) -> QPalette:
-        if self.__paletteOverride is not None:
-            return self.__paletteOverride
-        if self.__palette is not None:
-            return self.__palette
-        elif self.__style_object is not None:
-            palette = self.__paletteFromStyleObject(self.__style_object)
-            if palette is not None:
-                return palette
-
-        if self.__paletteOverride is not None:
-            return QPalette(self.__paletteOverride)
-        return QApplication.palette()
-
     def pixmap(self, size, mode, state):
         # type: (QSize, QIcon.Mode, QIcon.State) -> QPixmap
-        return self.__renderStyledPixmap(size, mode, state, self._palette())
+        return self.__renderStyledPixmap(size, mode, state, self.effectivePalette())
 
     def __renderStyledPixmap(
             self, size: QSize, mode: QIcon.Mode, state: QIcon.State,
@@ -203,7 +164,7 @@ class StyledSvgIconEngine(QIconEngine):
         disabled = mode == _QIcon_Disabled
         cg = _QPalette_Disabled if disabled else _QPalette_Active
         role = _QPalette_HighlightedText if active else _QPalette_WindowText
-        namespace = f"{__name__}:{__class__.__name__}/{self.__cache_key}/"
+        namespace = f"{__name__}:{__class__.__name__}/{self.__cache_key}"
         style_key = f"{hex(palette.cacheKey())}-{cg}-{role}"
         renderer = self.__styled_contents_cache.get(style_key)
         if renderer is None:
@@ -220,7 +181,7 @@ class StyledSvgIconEngine(QIconEngine):
         if not dsize.isNull():
             dsize.scale(size, _Qt_KeepAspectRatio)
             size = dsize
-        pmcachekey = f"{namespace}{style_key}/{size.width()}x{size.height()}"
+        pmcachekey = f"{namespace}/{style_key}/{size.width()}x{size.height()}"
         pm = QPixmapCache.find(pmcachekey)
         if pm is None or pm.isNull():
             pm = QPixmap(size)
@@ -243,25 +204,6 @@ class StyledSvgIconEngine(QIconEngine):
             palette=self.__palette,
             styleObject=self.__style_object
         )
-
-    __paletteOverride = None
-
-    @classmethod
-    @contextmanager
-    def setOverridePalette(cls, palette: QPalette):
-        """
-        Temporarily override used QApplication.palette() with this class.
-
-        This can be used when the icon is drawn on a non default background
-        and as such might not contrast with it when using the default palette,
-        and neither paint device nor styleObject can be used for this.
-        """
-        old = StyledSvgIconEngine.__paletteOverride
-        try:
-            StyledSvgIconEngine.__paletteOverride = palette
-            yield
-        finally:
-            StyledSvgIconEngine.__paletteOverride = old
 
 
 #: Like KDE's KIconLoader
@@ -300,7 +242,7 @@ def _hexrgb_solid(color: QColor) -> str:
     # (in hex or rgba syntax) so we pre-multiply with alpha to get solid
     # gray scale.
     if color.alpha() != 255:
-        contrast = QColor(Qt.black) if luminance(color) else QColor(Qt.white)
+        contrast = QColor(Qt.black) if luminance(color) > 0.5 else QColor(Qt.white)
         color = merged_color(color, contrast, color.alphaF())
     return color.name(QColor.HexRgb)
 

--- a/orangecanvas/gui/tests/test_iconengine.py
+++ b/orangecanvas/gui/tests/test_iconengine.py
@@ -1,0 +1,29 @@
+from AnyQt.QtCore import QSize, Qt
+from AnyQt.QtGui import QIcon, QPixmap, QColor, QPalette
+
+from ..iconengine import SymbolIconEngine
+
+from ..test import QAppTestCase
+
+
+class TestSymbolIconEngine(QAppTestCase):
+    def test(self):
+        pm = QPixmap(10, 10)
+        pm.fill(QColor(0, 0, 0))
+        base = QIcon()
+        base.addPixmap(pm)
+        engine = SymbolIconEngine(base)
+        palette = QPalette()
+        palette.setColor(QPalette.Text, QColor(200, 200, 200))
+        palette.setColor(QPalette.Base, QColor(Qt.black))
+        with SymbolIconEngine.setOverridePalette(palette):
+            img = engine.pixmap(QSize(10, 10), QIcon.Active, QIcon.Off).toImage()
+        pixel = QColor(img.pixel(5, 5))
+        self.assertEqual(QColor(pixel).name(), palette.text().color().name())
+
+        palette.setColor(QPalette.Text, QColor(Qt.black))
+        palette.setColor(QPalette.Base, QColor(Qt.white))
+        with SymbolIconEngine.setOverridePalette(palette):
+            img = engine.pixmap(QSize(10, 10), QIcon.Active, QIcon.Off).toImage()
+        pixel = QColor(img.pixel(5, 5))
+        self.assertEqual(QColor(pixel).name(), QColor(0, 0, 0).name())

--- a/orangecanvas/gui/toolbox.py
+++ b/orangecanvas/gui/toolbox.py
@@ -24,6 +24,8 @@ from AnyQt.QtCore import (
     Qt, QObject, QSize, QRect, QPoint, QSignalMapper
 )
 from AnyQt.QtCore import Signal, Property
+from .iconengine import StyledIconEngine
+from .. import styles
 
 from ..utils import set_flag
 from .utils import brush_darker, ScrollBar
@@ -218,7 +220,8 @@ class ToolBoxTabButton(QToolButton):
             icon_area_rect = icon_area_rect
             icon_rect = QRect(QPoint(0, 0), opt.iconSize)
             icon_rect.moveCenter(icon_area_rect.center())
-            opt.icon.paint(p, icon_rect, Qt.AlignCenter, mode, state)
+            with StyledIconEngine.setOverridePalette(styles.breeze_light()):
+                opt.icon.paint(p, icon_rect, Qt.AlignCenter, mode, state)
         p.restore()
 
 

--- a/orangecanvas/gui/utils.py
+++ b/orangecanvas/gui/utils.py
@@ -308,6 +308,17 @@ def create_gradient(base_color: QColor, stop=QPointF(0, 0),
     return grad
 
 
+def create_gradient_brush(color: QColor, stop=QPointF(0, 0),
+                          finalStop=QPointF(0, 1)) -> QBrush:
+    """
+    Create a linear gradient brush using `color` as a base.
+    """
+    grad = create_gradient(color, stop, finalStop)
+    brush = QBrush(grad)
+    brush.setColor(color)  # also record the base color
+    return brush
+
+
 def create_css_gradient(base_color: QColor, stop=QPointF(0, 0),
                         finalStop=QPointF(0, 1)) -> str:
     """

--- a/orangecanvas/registry/discovery.py
+++ b/orangecanvas/registry/discovery.py
@@ -66,7 +66,9 @@ def default_category_for_module(module):
         module = __import__(module, fromlist=[""])
     name = default_category_name_for_module(module)
     qualified_name = module.__name__
-    return CategoryDescription(name=name, qualified_name=qualified_name)
+    return CategoryDescription(
+        name=name, qualified_name=qualified_name, package=module.__package__
+    )
 
 
 class WidgetDiscovery(object):

--- a/orangecanvas/registry/utils.py
+++ b/orangecanvas/registry/utils.py
@@ -146,6 +146,7 @@ def category_from_package_globals(package):
     return CategoryDescription(
         name=name,
         qualified_name=qualified_name,
+        package=qualified_name,
         description=description,
         long_description=long_description,
         help=help,

--- a/orangecanvas/styles/__init__.py
+++ b/orangecanvas/styles/__init__.py
@@ -2,11 +2,14 @@
 """
 import os
 import re
-from typing import Mapping, Callable, Tuple, List
+from functools import wraps
+from typing import Mapping, Callable, Tuple, List, TypeVar
 
 import pkg_resources
 from AnyQt.QtCore import Qt
 from AnyQt.QtGui import QPalette, QColor
+
+_T = TypeVar("_T")
 
 
 def _make_palette(
@@ -42,6 +45,19 @@ def _make_palette(
     return palette
 
 
+def _once(f: _T) -> _T:
+    palette = None
+
+    @wraps(f)
+    def wrapper():
+        nonlocal palette
+        if palette is None:
+            palette = f()
+        return QPalette(palette)
+    return wrapper
+
+
+@_once
 def breeze_light() -> QPalette:
     # 'Breeze-Light' color scheme from KDE.
     return _make_palette(
@@ -59,6 +75,7 @@ def breeze_light() -> QPalette:
     )
 
 
+@_once
 def breeze_dark() -> QPalette:
     # 'Breeze Dark' color scheme from KDE.
     return _make_palette(
@@ -76,6 +93,7 @@ def breeze_dark() -> QPalette:
     )
 
 
+@_once
 def zion_reversed() -> QPalette:
     # 'Zion Reversed' color scheme from KDE.
     window = QColor(16, 16, 16)
@@ -94,6 +112,7 @@ def zion_reversed() -> QPalette:
     )
 
 
+@_once
 def dark():
     window = QColor(0x30, 0x30, 0x30)
     return _make_palette(

--- a/orangecanvas/utils/image.py
+++ b/orangecanvas/utils/image.py
@@ -1,0 +1,117 @@
+from typing import Sequence
+
+import numpy as np
+
+from AnyQt.QtGui import QImage, QColor
+
+
+def qrgb(
+        r: Sequence[int], g: Sequence[int], b: Sequence[int]
+) -> Sequence[int]:
+    """A vectorized `qRgb`."""
+    r, g, b = map(lambda a: np.asarray(a, dtype=np.uint32), (r, g, b))
+    return (0xff << 24) | ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff)
+
+
+def qrgba(
+        r: Sequence[int], g: Sequence[int], b: Sequence[int], a: Sequence[int]
+) -> Sequence[int]:
+    """A vectorized `qRgba`."""
+    r, g, b, a = map(lambda a: np.asarray(a, dtype=np.uint32), (r, g, b, a))
+    return ((a & 0xff) << 24) | ((r & 0xff) << 16) | ((g & 0xff) << 8) | (b & 0xff)
+
+
+def qgray(
+        r: Sequence[int], g: Sequence[int], b: Sequence[int]
+) -> Sequence[int]:
+    """A vectorized `qGray`."""
+    r, g, b = map(lambda a: np.asarray(a, dtype=np.uint16), (r, g, b))
+    return (r * 11 + g * 16 + b * 5) // 32
+
+
+def qred(rgb: Sequence[int]) -> Sequence[int]:
+    """A vectorized `qRed`."""
+    rgb = np.asarray(rgb, np.uint32)
+    return (rgb >> 16) & 0xff
+
+
+def qgreen(rgb: Sequence[int]) -> Sequence[int]:
+    """A vectorized `qGreen`."""
+    rgb = np.asarray(rgb, np.uint32)
+    return (rgb >> 8) & 0xff
+
+
+def qblue(rgb: Sequence[int]) -> Sequence[int]:
+    """A vectorized `qBlue`."""
+    rgb = np.asarray(rgb, np.uint32)
+    return rgb & 0xff
+
+
+def qalpha(rgb: Sequence[int]) -> Sequence[int]:
+    """A vectorized `qAlpha`."""
+    rgb = np.asarray(rgb, np.uint32)
+    return (rgb >> 24) & 0xff
+
+
+def grayscale_invert(
+        src: QImage, foreground: QColor, background: QColor
+) -> QImage:
+    """
+    Convert the `src` image to grayscale and invert it into background
+    to foreground (gray) range.
+
+    Parameters
+    ----------
+    src: QImage
+    foreground: QColor
+    background: QColor
+
+    Returns
+    -------
+    image: QImage
+    """
+    image = src.convertToFormat(QImage.Format_ARGB32)
+    size = image.size()
+    w, h = shape = size.width(), size.height()
+    buffer = image.bits().asarray(w * h * 4)
+    view = np.frombuffer(buffer, np.uint32).reshape(shape)
+    r, g, b, a = qred(view), qgreen(view), qblue(view), qalpha(view)
+    gray = qgray(r, g, b)
+    factor = gray / 255
+    foreground = qgray(foreground.red(), foreground.blue(), foreground.green())
+    background = qgray(background.red(), background.blue(), background.green())
+    if foreground > background:
+        minv_, maxv_ = background, foreground
+    else:
+        minv_, maxv_ = foreground, background
+    inv = (1 - factor) * (maxv_ - minv_) + minv_
+    inv = np.asarray(inv, np.uint8)
+    rgba = qrgba(inv, inv, inv, a)
+    res = QImage(w, h, QImage.Format_ARGB32)
+    return qimage_copy_from_buffer(res, rgba)
+
+
+def qimage_copy_from_buffer(image: QImage, data: np.ndarray) -> QImage:
+    """
+    Copy the `data` to `image`.
+
+    Parameters
+    ----------
+    image: QImage
+        The destination image.
+    data: np.ndarray
+        The raw source data in the same format as the `image`.
+    """
+    w, h = image.width(), image.height()
+    if data.shape != (w, h):
+        raise ValueError(
+            f"Wrong data.shape (expected ({w}, {h}) got {data.shape})"
+        )
+    d = image.depth() // 8
+    dtype = {
+        1: np.uint8, 2: np.uint16, 4: np.uint32, 8: np.uint64
+    }[d]
+    dest = image.bits().asarray(w * h * d)
+    dest = np.frombuffer(dest, dtype).reshape((w, h))
+    dest[:] = data
+    return image

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ INSTALL_REQUIRES = (
     "dictdiffer",
     "qasync",
     "importlib_metadata; python_version<'3.8'",
+    "numpy",
 )
 
 


### PR DESCRIPTION
### Issue

Fixes: gh-270

### Changes

Color widget icons based on current palette where appropriate.

By default when running in dark mode the colors are inverted to fit the background to foreground grayscale range.

![Screenshot_20230511_143619](https://github.com/biolab/orange-canvas-core/assets/4716745/25011427-c39a-43de-870c-558b17626c69)

![Screenshot_20230511_143839](https://github.com/biolab/orange-canvas-core/assets/4716745/c0f89da6-2e30-4176-9556-291c5ccf13b9)

Note that 'Color' is quite badly drawn.

But also add support for explicitly using *palette styled* widget icons like in https://github.com/biolab/orange3/pull/6444

![Screenshot_20230511_152623](https://github.com/biolab/orange-canvas-core/assets/4716745/b3e93e06-9981-4e1c-a0f5-663253ae110c)

![Screenshot_20230511_152231](https://github.com/biolab/orange-canvas-core/assets/4716745/f47b7cc7-dba5-472a-bfb6-0a90909b3816)
