### PR TITLE
[MNT] ci: Update ubuntu image for PyQt6 6.5 tests

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -49,9 +49,11 @@ jobs:
             python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: "3.11"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
+            extra-system-packages: "glibc-tools"
+
 
           # macOS
           - os: macos-11
@@ -116,10 +118,12 @@ jobs:
 
       - name: Install System Deps
         if: ${{ startsWith(runner.os, 'Linux') }}
+        env:
+          PACKAGES: ${{ matrix.extra-system-packages }}
         # https://www.riverbankcomputing.com/pipermail/pyqt/2020-June/042949.html
         run: |
           sudo apt-get update 
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0 libxcb-cursor0
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0 libxcb-cursor0 $PACKAGES
 
       - name: Setup Pip Cache
         uses: actions/cache@v3


### PR DESCRIPTION
### Issue

PyQt6 6.5 tests fail on ubuntu-20.04 due to
https://www.riverbankcomputing.com/pipermail/pyqt/2023-June/045313.html

### Changes

Use ubuntu-22.04 image