### PR TITLE
Evaluate values of dynamic signals before type checking

### DIFF
--- a/orangecanvas/scheme/signalmanager.py
+++ b/orangecanvas/scheme/signalmanager.py
@@ -1279,6 +1279,8 @@ def can_enable_dynamic(link, value):
     """
     Can the a dynamic `link` (:class:`SchemeLink`) be enabled for`value`.
     """
+    if LazyValue.is_lazy(value):
+        value = value.get_value()
     return isinstance(value, link.sink_types())
 
 


### PR DESCRIPTION
As proposed by @ales-erjavec, this fixes https://github.com/biolab/orange3/issues/6583.

Lazy signals are evaluating before checking their types. *If the signal is of the correct type*, it would eventually be evaluated anyway, so we don't lose anything.

If lazy signals had type hints, we could check the type before evaluation and save some memory when signals don't match. But this is an error condition and I won't lose sleep over it. Also, type hints would in most cases need to be added "manually" as an additional argument to `LazyValue`. In most widgets we would forger to do it, so signal manager would have to fall back to evaluation anyway.