### PR TITLE
[FIX] Ensure qasync loop is set as running

### DIFF
--- a/orangecanvas/utils/asyncutils.py
+++ b/orangecanvas/utils/asyncutils.py
@@ -44,4 +44,11 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
         # Do not use qasync.QEventLoop's default executor which uses QThread
         # based pool and exhibits https://github.com/numpy/numpy/issues/11551
         loop.set_default_executor(futures.ThreadPoolExecutor())
+        try:
+            # qasync>=0.24.2 no longer sets the running loop in QEventLoop
+            # constructor
+            get_running_loop()
+        except RuntimeError:
+            asyncio.events._set_running_loop(loop)
+    assert get_running_loop() is not None
     return loop

--- a/orangecanvas/utils/asyncutils.py
+++ b/orangecanvas/utils/asyncutils.py
@@ -1,9 +1,9 @@
-import os
 import asyncio
 from concurrent import futures
 from typing import Optional
 
 from AnyQt.QtCore import QCoreApplication, QThread
+import qasync
 
 
 def get_event_loop() -> asyncio.AbstractEventLoop:
@@ -31,13 +31,6 @@ def get_event_loop() -> asyncio.AbstractEventLoop:
     else:
         if loop is not None:
             return loop
-
-    qt_api = os.environ.get("QT_API", "").lower()
-    if qt_api == "pyqt5":
-        os.environ["QT_API"] = "PyQt5"
-    elif qt_api == "pyside2":
-        os.environ["QT_API"] = "PySide2"
-    import qasync
 
     if loop is None:
         loop = qasync.QEventLoop(app)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ INSTALL_REQUIRES = (
     "requests-cache",
     "pip>=18.0",
     "dictdiffer",
-    "qasync",
+    "qasync>=0.10.0",
     "importlib_metadata; python_version<'3.8'",
     "packaging",
     "numpy",


### PR DESCRIPTION
### Issue

Requesting help for a widget when using the latest released qasync v0.24.2 fails with an exception

```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/application/canvasmain.py", line 2352, in run
    url = await query_coro
          ^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/help/manager.py", line 127, in search_async
    return await provider.search_async(desc, timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/help/provider.py", line 133, in search_async
    await asyncio.wait_for(reply_f, timeout)
  File "/Users/aleserjavec/.local/opt/python3.11/Python.framework/Versions/3.11/lib/python3.11/asyncio/tasks.py", line 439, in wait_for
    loop = events.get_running_loop()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: no running event loop
```
### Changes

* Ensure qasync loop is set as the running loop.
* Some minor cleanup.