### PR TITLE
[MNT] readthedocs: Remove no longer supported 'system_packages'

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,5 +5,3 @@ python:
    install:
       - requirements: docs/requirements-rtd.txt
       # no - method: pip here, -e . is already in docs/requirements-rtd.txt
-
-   system_packages: true


### PR DESCRIPTION
### Issue

RTD docs build [fails](https://readthedocs.org/projects/orange-canvas-core/builds/22141919/) due to dropped [system_packages](https://blog.readthedocs.com/drop-support-system-packages/) key 

### Changes

Remove `system_packages` key
