### PR TITLE
[FIX] widgettoolbox: Fix WidgetToolBox tests with Python 3.12

### DIFF
--- a/orangecanvas/application/tests/test_widgettoolbox.py
+++ b/orangecanvas/application/tests/test_widgettoolbox.py
@@ -24,6 +24,11 @@ class TestWidgetToolBox(test.QAppTestCase):
         reg = registry_tests.small_testing_registry()
         self.reg = QtWidgetRegistry(reg)
 
+    def tearDown(self):
+        self.reg.model().clear()
+        del self.reg
+        super().tearDown()
+
     def test_widgettoolgrid(self):
         w = QWidget()
         layout = QHBoxLayout()

--- a/orangecanvas/application/widgettoolbox.py
+++ b/orangecanvas/application/widgettoolbox.py
@@ -108,6 +108,7 @@ class WidgetToolGrid(ToolGrid):
         if self.__model is not None:
             self.__model.rowsInserted.disconnect(self.__on_rowsInserted)
             self.__model.rowsRemoved.disconnect(self.__on_rowsRemoved)
+            self.__model.modelReset.disconnect(self.__on_modelReset)
             self.__model = None
 
         self.__model = model
@@ -116,6 +117,7 @@ class WidgetToolGrid(ToolGrid):
         if self.__model is not None:
             self.__model.rowsInserted.connect(self.__on_rowsInserted)
             self.__model.rowsRemoved.connect(self.__on_rowsRemoved)
+            self.__model.modelReset.connect(self.__on_modelReset)
 
         self.__initFromModel(model, rootIndex)
 
@@ -214,8 +216,14 @@ class WidgetToolGrid(ToolGrid):
         if parent == QModelIndex(self.__rootIndex):
             actions = self.actions()
             actions = actions[start: end + 1]
-            for action in actions:
-                self.removeAction(action)
+            self.__removeActions(actions)
+
+    def __on_modelReset(self):
+        self.__removeActions(self.actions())
+
+    def __removeActions(self, actions: Iterable[QAction]):
+        for action in actions:
+            self.removeAction(action)
 
     def __startDrag(self, button):
         # type: (QToolButton) -> None
@@ -297,6 +305,7 @@ class WidgetToolBox(ToolBox):
         self.__proxyModel.dataChanged.connect(self.__on_dataChanged)
         self.__proxyModel.rowsInserted.connect(self.__on_rowsInserted)
         self.__proxyModel.rowsRemoved.connect(self.__on_rowsRemoved)
+        self.__proxyModel.modelReset.connect(self.__on_modelReset)
 
         self.__iconSize = QSize(25, 25)
         self.__buttonSize = QSize(50, 50)
@@ -499,6 +508,10 @@ class WidgetToolBox(ToolBox):
         if not parent.isValid():
             for i in reversed(range(start, end + 1)):
                 self.removeItem(i)
+
+    def __on_modelReset(self):
+        for i in reversed(range(self.count())):
+            self.removeItem(i)
 
     def __on_filterTextChanged(self, text: str) -> None:
         def acceptable(desc: Optional[WidgetDescription]) -> bool:


### PR DESCRIPTION
### Issue

Running unittests on Python 3.12 aborts with 

```
...
test_filter (orangecanvas.application.tests.test_widgettoolbox.TestWidgetToolBox.test_filter) ... ok
Traceback (most recent call last):
  File "/home/ales/devel/orange-canvas-core/orangecanvas/application/widgettoolbox.py", line 161, in actionEvent
    button = self.buttonForAction(event.action())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ales/devel/orange-canvas-core/orangecanvas/gui/toolgrid.py", line 345, in buttonForAction
    index = actions.index(action)
            ^^^^^^^^^^^^^^^^^^^^^
ValueError: <PyQt6.QtGui.QAction object at 0x7fd2b44b48a0> is not in list
Fatal Python error: Aborted
```

### Changes

Handle model reset and use model reset in test tearDown to avoid errors in tests.
