### PR TITLE
[FIX] nodeitem: Update opened anchor on link completion

### DIFF
--- a/orangecanvas/canvas/items/nodeitem.py
+++ b/orangecanvas/canvas/items/nodeitem.py
@@ -639,6 +639,7 @@ class NodeAnchorItem(GraphicsPathObject):
         else:
             self.__keepSignalsOpen = signal
         self.__updateLabels(self.__keepSignalsOpen)
+        self.__updatePositions()
 
     def parentNodeItem(self):
         # type: () -> Optional['NodeItem']


### PR DESCRIPTION
### Issue


When Shift dragging a new connection from an expanded channel anchor to an empty spot on the canvas and not completing the interaction (i.e. canceling it) then the connection anchor remains open.

Similar to gh-272 except that the connection needs to be dragged to an empty spot and then closing the new node menu.

### Changes

Update anchor positions when changing state.