### PR TITLE
[FIX] view: Fix a type error with PyQt6

### DIFF
--- a/orangecanvas/canvas/tests/test_view.py
+++ b/orangecanvas/canvas/tests/test_view.py
@@ -1,0 +1,27 @@
+from AnyQt.QtCore import QPointF, QRect
+
+from orangecanvas.gui.test import QAppTestCase
+from orangecanvas.canvas import view, scene
+
+
+class TestView(QAppTestCase):
+    def setUp(self):
+        super().setUp()
+        self.scene = scene.CanvasScene()
+        self.view = view.CanvasView(self.scene)
+        self.view.resize(420, 420)
+        self.scene.setSceneRect(0, 0, 400, 400)
+
+    def tearDown(self):
+        self.scene.clear()
+        del self.view
+        del self.scene
+        super().tearDown()
+
+    def test_view_pinch_zoom(self):
+        # Missing QTest.touchEvent in PyQt; cannot properly simulate touch
+        # events so test this the ugly way.
+        anchor = QPointF(350, 350)
+        self.view._CanvasView__setZoomLevel(5.0, anchor)
+        mapped = self.view.mapFromScene(anchor)
+        self.assertTrue(self.view.viewport().rect().contains(mapped))

--- a/orangecanvas/canvas/view.py
+++ b/orangecanvas/canvas/view.py
@@ -196,7 +196,7 @@ class CanvasView(QGraphicsView):
             if anchor is not None:
                 center = self.viewport().rect().center()
                 diff = self.mapToScene(center) - self.mapToScene(anchor)
-                self.centerOn(anchor + diff)
+                self.centerOn(QPointF(anchor) + diff)
             self.zoomLevelChanged.emit(scale)
 
     zoomLevelChanged = Signal(float)


### PR DESCRIPTION
### Issue

Using pinch gesture on the canvas when using PyQt6 causes an error
```
----------------------------------------------------------------------
Traceback (most recent call last):
 ...
  File "/home/ales/devel/orange-canvas-core/orangecanvas/canvas/view.py", line 199, in __setZoomLevel
    self.centerOn(anchor + diff)
                  ~~~~~~~^~~~~~
TypeError: unsupported operand type(s) for +: 'QPoint' and 'QPointF'

----------------------------------------------------------------------
```
### Changes

Cast the anchor to QPointF
