### PR TITLE
[MNT] readthedocs:  Add build.os key

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 python:
-   version: "3.7"
    install:
       - requirements: docs/requirements-rtd.txt
       # no - method: pip here, -e . is already in docs/requirements-rtd.txt


### PR DESCRIPTION
### Issue

RTD docs build [fails](https://readthedocs.org/projects/orange-canvas-core/builds/22266727/) due to missing [build.os key](https://blog.readthedocs.com/use-build-os-config/) 



### Changes

Add build.os key