### PR TITLE
[ENH] Remove use of pkg_resources

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,8 @@ import sys
 import os
 import shlex
 
-import pkg_resources
-dist = pkg_resources.get_distribution("orange-canvas-core")
+import importlib_metadata
+dist = importlib_metadata.distribution("orange-canvas-core")
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -1354,7 +1354,7 @@ class CanvasMainWindow(QMainWindow):
         dlg.setStyle(QApplication.style())
         dlg.setConfig(config.default)
         req = addons.Requirement
-        names = [req.parse(r).project_name for r in requires]
+        names = [req(r).name for r in requires]
         normalized_names = {normalize_name(r) for r in names}
 
         def set_state(*args):

--- a/orangecanvas/application/tests/test_main.py
+++ b/orangecanvas/application/tests/test_main.py
@@ -7,13 +7,14 @@ from unittest.mock import patch, Mock
 
 from orangecanvas import config
 from orangecanvas.application.canvasmain import CanvasMainWindow
-from orangecanvas.config import Config, EntryPoint
+from orangecanvas.config import Config
 from orangecanvas.gui.test import QAppTestCase
 from orangecanvas.main import Main
 from orangecanvas.registry import WidgetDiscovery
 from orangecanvas.registry.tests import set_up_modules, tear_down_modules
 from orangecanvas.scheme import Scheme
 from orangecanvas.utils.shtools import temp_named_file
+from orangecanvas.utils.pkgmeta import EntryPoint
 
 
 class TestMain(unittest.TestCase):
@@ -76,12 +77,15 @@ class TestConfig(Config):
     def widgets_entry_points(self):  # type: () -> Iterable[EntryPoint]
         pkg = "orangecanvas.registry.tests"
         return (
-            EntryPoint.parse(f"add = {pkg}.operators.add"),
-            EntryPoint.parse(f"sub = {pkg}.operators.sub")
+            EntryPoint("add", f"{pkg}.operators.add", "w"),
+            EntryPoint("sub", f"{pkg}.operators.sub", "w")
         )
 
     def workflow_constructor(self, *args, **kwargs):
         return Scheme(*args, **kwargs)
+
+    def splash_screen(self):
+        return config.Default.splash_screen()
 
 
 class TestMainGuiCase(QAppTestCase):

--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -46,6 +46,7 @@ from ..gui.quickhelp import QuickHelpTipEvent
 from . import commands
 from .editlinksdialog import EditLinksDialog
 from ..utils import unique
+from ..utils.pkgmeta import EntryPoint, entry_points
 
 if typing.TYPE_CHECKING:
     from .schemeedit import SchemeEditWidget
@@ -53,12 +54,6 @@ if typing.TYPE_CHECKING:
     A = typing.TypeVar("A")
     #: Output/Input pair of a link
     OIPair = Tuple[OutputSignal, InputSignal]
-
-try:
-    from importlib.metadata import EntryPoint, entry_points
-except ImportError:
-    from importlib_metadata import EntryPoint, entry_points
-
 
 log = logging.getLogger(__name__)
 
@@ -2021,7 +2016,7 @@ class PluginDropHandler(DropHandler):
         """
         Return an iterator over all entry points.
         """
-        eps = entry_points().get(self.__group, [])
+        eps = entry_points(group=self.__group)
         # Can have duplicated entries here if a distribution is *found* via
         # different `sys.meta_path` handlers and/or on different `sys.path`
         # entries.

--- a/orangecanvas/document/tests/test_schemeedit.py
+++ b/orangecanvas/document/tests/test_schemeedit.py
@@ -557,7 +557,6 @@ class TestSchemeEdit(QAppTestCase):
 
     @mock.patch.object(
         PluginDropHandler, "iterEntryPoints",
-        # "pkg_resources.WorkingSet.iter_entry_points",
         lambda _: [
             EntryPoint(
                 "AA", f"{__name__}:TestDropHandler", "aa"

--- a/orangecanvas/gui/tests/test_splashscreen.py
+++ b/orangecanvas/gui/tests/test_splashscreen.py
@@ -1,12 +1,10 @@
 """
 Test for splashscreen
 """
-
+import pkgutil
 from datetime import datetime
 
-import pkg_resources
-
-from AnyQt.QtGui import QPixmap
+from AnyQt.QtGui import QPixmap, QImage
 from AnyQt.QtCore import Qt, QRect, QTimer
 
 from ..splashscreen import SplashScreen
@@ -17,11 +15,12 @@ from ... import config
 
 class TestSplashScreen(QAppTestCase):
     def test_splashscreen(self):
-        splash = pkg_resources.resource_filename(
+        contents = pkgutil.get_data(
             config.__package__, "icons/orange-canvas-core-splash.svg"
         )
+        img = QImage.fromData(contents)
         w = SplashScreen()
-        w.setPixmap(QPixmap(splash))
+        w.setPixmap(QPixmap.fromImage(img))
         w.setTextRect(QRect(100, 100, 400, 50))
         w.show()
 

--- a/orangecanvas/help/tests/test_manager.py
+++ b/orangecanvas/help/tests/test_manager.py
@@ -1,0 +1,57 @@
+import os.path
+from unittest.mock import patch
+from types import SimpleNamespace as ns
+
+from orangecanvas.gui.test import QCoreAppTestCase
+from orangecanvas.help import HelpManager
+from orangecanvas.help.provider import HtmlIndexProvider
+from orangecanvas.registry.tests import small_testing_registry
+from orangecanvas.utils import pkgmeta
+
+
+class FakeDistribution(pkgmeta.Distribution):
+    def read_text(self, filename):
+        pass
+
+    def locate_file(self, path):
+        return os.path.join(os.path.devnull, path)
+
+    _entry_points = None
+    _name = None
+    _version = None
+
+    def __init__(self, name, version, eps):
+        self._name = name
+        self._version = version
+        self._entry_points = eps
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def entry_points(self):
+        return self._entry_points
+
+
+HELP_PATHS = (
+    ("https://example.com/help", ""),
+)
+
+
+class TestHelpManager(QCoreAppTestCase):
+    def test_manager(self):
+        manager = HelpManager()
+        reg = small_testing_registry()
+        manager.set_registry(reg)
+        ep = pkgmeta.EntryPoint("html-index", f"{__name__}:HELP_PATHS", "-")
+        eps = ns(select=lambda *_, **__: [ep])
+        dist = FakeDistribution("foo", "0.0", eps)
+        vars(ep).update(dist=dist)
+        with patch("orangecanvas.help.manager.get_distribution", lambda *_: dist):
+            provider = manager.get_provider("foobar")
+            self.assertIsInstance(provider, HtmlIndexProvider)

--- a/orangecanvas/preview/tests/test_previewbrowser.py
+++ b/orangecanvas/preview/tests/test_previewbrowser.py
@@ -2,19 +2,16 @@
 Unittests for PrewiewBrowser widget.
 
 """
+import pkgutil
+
 from ...gui import test
 
 from ..previewbrowser import PreviewBrowser
 from ..previewmodel import PreviewItem, PreviewModel
 from ... import config
 
-import pkg_resources
-
-svg1 = pkg_resources.resource_string(config.__package__,
-                                     "icons/default-category.svg")
-
-svg2 = pkg_resources.resource_string(config.__package__,
-                                     "icons/default-widget.svg")
+svg1 = pkgutil.get_data(config.__package__, "icons/default-category.svg")
+svg2 = pkgutil.get_data(config.__package__, "icons/default-widget.svg")
 
 
 def construct_test_preview_model():

--- a/orangecanvas/registry/description.py
+++ b/orangecanvas/registry/description.py
@@ -456,7 +456,7 @@ class CategoryDescription(object):
     priority : int
         Priority (order in the GUI).
     icon : str
-        An icon filename (a resource name retrievable using `pkg_resources`
+        An icon filename (a resource name retrievable using `pkgutil.get_data`
         relative to `qualified_name`).
     background : str
         An background color for widgets in this category.

--- a/orangecanvas/registry/tests/test_discovery.py
+++ b/orangecanvas/registry/tests/test_discovery.py
@@ -9,6 +9,7 @@ import unittest
 from ..discovery import WidgetDiscovery, widget_descriptions_from_package
 from ..description import CategoryDescription, WidgetDescription
 from ..utils import category_from_package_globals
+from ...utils.pkgmeta import get_distribution
 
 
 class TestDiscovery(unittest.TestCase):
@@ -40,8 +41,9 @@ class TestDiscovery(unittest.TestCase):
 
     def test_process_module(self):
         disc = self.discovery_class()
-        disc.process_category_package(self.operators.__name__)
-        disc.process_widget_module(self.constants.one.__name__)
+        dist = get_distribution("orange-canvas-core")
+        disc.process_category_package(self.operators.__name__, distribution=dist)
+        disc.process_widget_module(self.constants.one.__name__, distribution=dist)
 
     def test_process_loader(self):
         disc = self.discovery_class()

--- a/orangecanvas/styles/__init__.py
+++ b/orangecanvas/styles/__init__.py
@@ -1,11 +1,11 @@
 """
 """
 import os
+import pkgutil
 import re
 from functools import wraps
 from typing import Mapping, Callable, Tuple, List, TypeVar
 
-import pkg_resources
 from AnyQt.QtCore import Qt
 from AnyQt.QtGui import QPalette, QColor
 
@@ -182,12 +182,11 @@ def style_sheet(stylesheet: str) -> Tuple[str, List[Tuple[str, str]]]:
         # no extension
         stylesheet = os.path.extsep.join([stylesheet, "qss"])
 
-    pkg_name = __package__
     resource = stylesheet
-
-    if pkg_resources.resource_exists(pkg_name, resource):
-        stylesheet_string = \
-            pkg_resources.resource_string(pkg_name, resource).decode("utf-8")
-        base = pkg_resources.resource_filename(pkg_name, "")
-        return process_qss(stylesheet_string, base)
-    return stylesheet_string, []
+    try:
+        stylesheet_string = pkgutil.get_data(__package__, resource)
+    except FileNotFoundError:
+        return stylesheet_string, []
+    else:
+        return process_qss(stylesheet_string.decode("utf-8"),
+                           os.path.basename(__file__))

--- a/orangecanvas/utils/pkgmeta.py
+++ b/orangecanvas/utils/pkgmeta.py
@@ -7,10 +7,11 @@ from typing import List, Dict, Optional, Union, cast
 
 import packaging.version
 
-try:
-    from importlib.metadata import EntryPoint, Distribution, entry_points, PackageNotFoundError
-except ImportError:
+if sys.version_info < (3, 10):
     from importlib_metadata import EntryPoint, Distribution, entry_points, PackageNotFoundError
+else:
+    from importlib.metadata import EntryPoint, Distribution, entry_points, PackageNotFoundError
+
 
 __all__ = [
     "Distribution", "EntryPoint", "entry_points", "normalize_name", "trim",

--- a/orangecanvas/utils/pkgmeta.py
+++ b/orangecanvas/utils/pkgmeta.py
@@ -8,13 +8,14 @@ from typing import List, Dict, Optional, Union, cast
 import packaging.version
 
 try:
-    from importlib.metadata import EntryPoint, Distribution, entry_points
+    from importlib.metadata import EntryPoint, Distribution, entry_points, PackageNotFoundError
 except ImportError:
-    from importlib_metadata import EntryPoint, Distribution, entry_points
+    from importlib_metadata import EntryPoint, Distribution, entry_points, PackageNotFoundError
 
 __all__ = [
     "Distribution", "EntryPoint", "entry_points", "normalize_name", "trim",
     "trim_leading_lines", "trim_trailing_lines", "parse_meta", "get_dist_meta",
+    "get_distribution"
 ]
 
 
@@ -132,3 +133,10 @@ def get_dist_meta(dist: Distribution) -> Dict[str, Union[str, List[str]]]:
         else:
             meta[key] = metadata[key]
     return meta
+
+
+def get_distribution(name: str) -> Optional[Distribution]:
+    try:
+        return Distribution.from_name(name)
+    except PackageNotFoundError:
+        return None

--- a/orangecanvas/utils/tests/test_pkgmeta.py
+++ b/orangecanvas/utils/tests/test_pkgmeta.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+
+from orangecanvas.utils.pkgmeta import (
+    Distribution, normalize_name, is_develop_egg, get_dist_meta, parse_meta,
+    trim,
+)
+
+
+class TestPkgMeta(TestCase):
+    def test_normalize_name(self):
+        self.assertEqual(normalize_name("a-c_4"), "a_c_4")
+
+    def test_is_develop_egg(self):
+        d = Distribution.from_name("AnyQt")
+        is_develop_egg(d)
+        try:
+            d = Distribution.from_name("orange-canvas-core")
+        except Exception:
+            pass
+        else:
+            is_develop_egg(d)
+
+    def test_get_dist_meta(self):
+        d = Distribution.from_name("AnyQt")
+        meta = get_dist_meta(d)
+        self.assertEqual(meta["Name"], "AnyQt")
+
+    def test_parse_meta(self):
+        m = parse_meta(trim("""
+            Metadata-Version: 1.0
+            Name: AA
+            Version: 0.1
+            Requires-Dist: foo
+            Requires-Dist: bar
+        """))
+        self.assertEqual(m["Name"], "AA")
+        self.assertEqual(m["Version"], "0.1")
+        self.assertEqual(m["Requires-Dist"], ["foo", "bar"])
+
+    def test_trim(self):
+        self.assertEqual(trim("A\n    a\n    b"), "A\na\nb")

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ INSTALL_REQUIRES = (
     "pip>=18.0",
     "dictdiffer",
     "qasync>=0.10.0",
-    "importlib_metadata; python_version<'3.8'",
+    "importlib_metadata; python_version<'3.10'",
     "importlib_resources; python_version<'3.9'",
     "packaging",
     "numpy",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ INSTALL_REQUIRES = (
     "dictdiffer",
     "qasync>=0.10.0",
     "importlib_metadata; python_version<'3.8'",
+    "importlib_resources; python_version<'3.9'",
     "packaging",
     "numpy",
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 NAME = "orange-canvas-core"
-VERSION = "0.1.36.dev0"
+VERSION = "0.2.0a1.dev0"
 DESCRIPTION = "Core component of Orange Canvas"
 
 with open("README.rst", "rt", encoding="utf-8") as f:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ PACKAGE_DATA = {
 }
 
 INSTALL_REQUIRES = (
-    "setuptools",
     "AnyQt>=0.2.0",
     "docutils",
     "commonmark>=0.8.1",


### PR DESCRIPTION
### Issue

[pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html)  is deprecated.

### Changes

Remove/replace use of pkg_resources with importlib.metadata, importlib.resources, pkgutil and packaging.

This also bumps version to 0.2.* because it is backwards incompatible due to differences in exposed types in the discovery process. This should trigger the `orange-canvas-core>=0.1.30,<0.2a` condition in https://github.com/biolab/orange3/blob/78f7b30a89a7b78ef6442f0b828f41a6f5c27951/requirements-gui.txt#L1