### PR TITLE
Add language setting and translation function

### DIFF
--- a/orangecanvas/application/settings.py
+++ b/orangecanvas/application/settings.py
@@ -277,14 +277,22 @@ class UserSettingsDialog(QMainWindow):
 
         languages = get_languages()
         if languages:
+            langlay = QHBoxLayout()
+            label = QLabel(
+                "Changes will take effect on next application startup.")
+            label.setHidden(True)
+
             cm_lang = QComboBox(
                 objectName="combo-language",
                 toolTip=self.tr("Select the application language.")
             )
             cm_lang.addItems(languages)
             self.bind(cm_lang, "currentText", "application/language")
+            cm_lang.currentTextChanged.connect(lambda: label.setHidden(False))
 
-            form.addRow(self.tr("Language"), cm_lang)
+            langlay.addWidget(cm_lang)
+            langlay.addWidget(label)
+            form.addRow(self.tr("Language"), langlay)
 
         nodes = QWidget(self, objectName="nodes")
         nodes.setLayout(QVBoxLayout())

--- a/orangecanvas/application/settings.py
+++ b/orangecanvas/application/settings.py
@@ -21,6 +21,7 @@ from AnyQt.QtCore import (
     Signal)
 
 from .. import config
+from ..utils.localization import get_languages
 from ..utils.settings import SettingChangedEvent
 from ..utils.propertybindings import (
     AbstractBoundProperty, PropertyBinding, BindingManager
@@ -273,6 +274,17 @@ class UserSettingsDialog(QMainWindow):
 
         form = FormLayout()
         tab.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        languages = get_languages()
+        if languages:
+            cm_lang = QComboBox(
+                objectName="combo-language",
+                toolTip=self.tr("Select the application language.")
+            )
+            cm_lang.addItems(languages)
+            self.bind(cm_lang, "currentText", "application/language")
+
+            form.addRow(self.tr("Language"), cm_lang)
 
         nodes = QWidget(self, objectName="nodes")
         nodes.setLayout(QVBoxLayout())

--- a/orangecanvas/config.py
+++ b/orangecanvas/config.py
@@ -364,6 +364,12 @@ spec = \
      ("startup/load-crashed-workflows", bool, True,
       "Load crashed scratch workflows on startup"),
 
+     ("application/language", str, "English",
+      "Application language"),
+
+     ("application/last-used-language", str, "English",
+      "If different from application/language, widget discovery is forced"),
+
      ("stylesheet", str, "orange",
       "QSS stylesheet to use"),
 

--- a/orangecanvas/main.py
+++ b/orangecanvas/main.py
@@ -16,6 +16,7 @@ from contextlib import ExitStack, closing
 from AnyQt.QtGui import QFont, QColor, QPalette
 from AnyQt.QtCore import Qt, QSettings, QTimer, QUrl, QDir
 
+from orangecanvas.utils import localization
 from .utils.after_exit import run_after_exit
 from .styles import style_sheet, breeze_dark as _breeze_dark
 from .application.application import CanvasApplication
@@ -142,7 +143,8 @@ class Main:
         Run the widget discovery and return the resulting registry.
         """
         options = self.options
-        if not options.force_discovery:
+        language_changed = localization.language_changed()
+        if not (options.force_discovery or language_changed):
             reg_cache = cache.registry_cache()
         else:
             reg_cache = None
@@ -168,6 +170,8 @@ class Main:
             with open(cache_filename, "wb") as f:
                 pickle.dump(WidgetRegistry(widget_registry), f)
         self.registry = widget_registry
+        if language_changed:
+            localization.update_last_used_language()
         self.close_splash_screen()
         return widget_registry
 

--- a/orangecanvas/utils/localization/__init__.py
+++ b/orangecanvas/utils/localization/__init__.py
@@ -2,7 +2,7 @@ import os
 import json
 import importlib
 
-from AnyQt.QtCore import QSettings
+from AnyQt.QtCore import QSettings, QLocale
 
 def pl(n: int, forms: str) -> str:  # pylint: disable=invalid-name
     """
@@ -49,10 +49,15 @@ def get_languages(package=None):
             if ext == ".json"]
 
 
+DEFAULT_LANGUAGE = QLocale().languageToString(QLocale().language())
+if DEFAULT_LANGUAGE not in get_languages():
+    DEFAULT_LANGUAGE = "English"
+
+
 def language_changed():
     s = QSettings()
-    lang = s.value("application/language", "English")
-    last_lang = s.value("application/last-used-language", "English")
+    lang = s.value("application/language", DEFAULT_LANGUAGE)
+    last_lang = s.value("application/last-used-language", DEFAULT_LANGUAGE)
     return lang != last_lang
 
 
@@ -68,14 +73,14 @@ class Translator:
     def __init__(self, package, organization="biolab.si", application="Orange"):
         s = QSettings(QSettings.IniFormat, QSettings.UserScope,
                       organization, application)
-        lang = s.value("application/language", "English")
+        lang = s.value("application/language", DEFAULT_LANGUAGE)
         # For testing purposes (and potential fallback)
         # lang = os.environ.get("ORANGE_LANG", "English")
         package_path = os.path.dirname(importlib.import_module(package).__file__)
         path = os.path.join(package_path, "i18n", f"{lang}.json")
         if not os.path.exists(path):
-            path = os.path.join(package_path, "i18n", "English.json")
-        assert os.path.exists(path)
+            path = os.path.join(package_path, "i18n", f"{DEFAULT_LANGUAGE}.json")
+        assert os.path.exists(path), f"Missing language file {path}"
         self.m = json.load(open(path))
 
     def c(self, idx):

--- a/orangecanvas/utils/localization/__init__.py
+++ b/orangecanvas/utils/localization/__init__.py
@@ -49,6 +49,19 @@ def get_languages(package=None):
             if ext == ".json"]
 
 
+def language_changed():
+    s = QSettings()
+    lang = s.value("application/language", "English")
+    last_lang = s.value("application/last-used-language", "English")
+    return lang != last_lang
+
+
+def update_last_used_language():
+    s = QSettings()
+    lang = s.value("application/language", "English")
+    s.setValue("application/last-used-language", lang)
+
+
 class Translator:
     e = eval
 


### PR DESCRIPTION
This adds a language selector to the settings dialog. It will allow us to prepare multilingual distributions of Orange, which we urgently need for various education-related projects.

The change is only visible if distribution includes message files that are prepared by (so far unpublished new version of) Trubar.

Caveats:

- Language must be detected at the very beginning because some modules (even modules like `Orange.data.table` may already include translated strings). This is why language is read from `QSettings(QSettings.IniFormat, QSettings.UserScope, organization, application)` and not just `QSettings()` because `QApplication` is not set up at that point yet. Organization and application are specified in Trubar's configuration files, to allow Trubar to insert the following at the beginning of each module (after imports from future):

    ```
    from orangecanvas.utils.localization import Translator  # pylint: disable=wrong-import-order
    _tr = Translator("orangecontrib.prototypes", "biolab.si", "Orange")
    del Translator
    ```

- After changing the language, Orange must be re-run with `--force-discovery`. This belongs to this PR, but is not implemented yet.

@ales-erjavec, do you have any comments?

--------

#### To do:

- [x] Restart with force-discovery, or a message that changing this setting will take effect after restarting, and then at the restart compare the previous and the new language and trigger force-discovery if needed.
- [x] Use system locale to set default language
- [ ] In message files, add language name in English and in native language; also provide place for any other info we may want to add in the future.
 
--------

I'm attaching examples of core files and some add-ons. Strings are simply looked up in a table, e.g.

```
        gui.button(box, self, "Save", callback=self.save)
        gui.button(box, self, "Load", callback=self.load)
        gui.button(box, self, "Reset", callback=self.reset)
```

becomes

```
        gui.button(box, self, _tr.m[233], callback=self.save)
        gui.button(box, self, _tr.m[234], callback=self.load)
        gui.button(box, self, _tr.m[235], callback=self.reset)
```

while f-strings, like

```
            tpe = f"Random sample with {self.sampleSizePercentage} % of data"
```

are compiled and evaluated,

```
            tpe = _tr.e(_tr.c(573))
```

`m`, `c` and `e` are attributes of `Translator` class from this PR.

[orange3.zip](https://github.com/biolab/orange-canvas-core/files/15067111/orange3.zip)
[orange-canvas-core.zip](https://github.com/biolab/orange-canvas-core/files/15067114/orange-canvas-core.zip)
[orange-widget-base.zip](https://github.com/biolab/orange-canvas-core/files/15067116/orange-widget-base.zip)
[orange3-imageanalytics.zip](https://github.com/biolab/orange-canvas-core/files/15067120/orange3-imageanalytics.zip)
[orange3-geo.zip](https://github.com/biolab/orange-canvas-core/files/15067181/orange3-geo.zip)
[orange3-network.zip](https://github.com/biolab/orange-canvas-core/files/15067184/orange3-network.zip)

Preparation of these files is not a part of this PR. 