### PR TITLE
[FIX] application: Fix default application font on windows (QTBUG-61707)

### DIFF
--- a/orangecanvas/application/application.py
+++ b/orangecanvas/application/application.py
@@ -151,6 +151,9 @@ class CanvasApplication(QApplication):
                 sh.setShowShortcutsInContextMenus(True)
         if QT_VERSION_INFO < (5, 15):  # QTBUG-61707
             macos_set_nswindow_tabbing(False)
+        if QT_VERSION_INFO < (6, 0):  # QTBUG-58610
+            # https://github.com/musescore/MuseScore/pull/5820
+            QApplication.setFont(QApplication.font("QMessageBox"))
         self.configureStyle()
 
     def event(self, event):


### PR DESCRIPTION
### Issue

Fixes: https://github.com/biolab/orange3/issues/6826

Qt5 uses obsolete MS Dlg Shell 2 'virtual' font by default.

### Changes

As per https://github.com/musescore/MuseScore/pull/5791#issuecomment-596669064 `QApplication.font("QMessageBox")` has the correct computed font so set that as the default.
