### PR TITLE
[FIX] setup.py: Specify minimum importlib-metadata version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ INSTALL_REQUIRES = (
     "pip>=18.0",
     "dictdiffer",
     "qasync>=0.10.0",
-    "importlib_metadata; python_version<'3.10'",
+    "importlib_metadata>=4.6; python_version<'3.10'",
     "importlib_resources; python_version<'3.9'",
     "packaging",
     "numpy",


### PR DESCRIPTION
### Issue

Fixes https://github.com/biolab/orange3/issues/6831

### Changes 

Specify minimum importlib-metadata version