### PR TITLE
[FIX] styles: Fix package base path (fixes dropdown indicators)

### DIFF
--- a/orangecanvas/styles/__init__.py
+++ b/orangecanvas/styles/__init__.py
@@ -189,4 +189,4 @@ def style_sheet(stylesheet: str) -> Tuple[str, List[Tuple[str, str]]]:
         return stylesheet_string, []
     else:
         return process_qss(stylesheet_string.decode("utf-8"),
-                           os.path.basename(__file__))
+                           os.path.dirname(__file__))


### PR DESCRIPTION
### Issue

Fixes: https://github.com/biolab/orange3/issues/6837

This error causes missing dropdown indicators in the bottom toolbar

<img width="111" alt="Screenshot 2024-07-16 at 11 28 50" src="https://github.com/user-attachments/assets/97702931-f2ec-44cf-ad6c-59f42e204565">
<img width="111" alt="Screenshot 2024-07-16 at 11 30 36" src="https://github.com/user-attachments/assets/b0c38a53-d5eb-4e6c-a8f2-056d4ac4b44e">

This does not apply and cannot be replicated using dark style

### Changes


Fix package base path
