### PR TITLE
[FIX] schemeedit: Avoid replicated node renumbering on paste

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -2046,6 +2046,8 @@ document/schemeedit.py:
     Cs: false
     Co: false
     Cn: false
+    def `remove_copy_number`:
+        \s+\(\d+\)\s*$: false
     def `uniquify`:
         {item}-{_}: false
 document/suggestions.py:

--- a/orangecanvas/document/tests/test_schemeedit.py
+++ b/orangecanvas/document/tests/test_schemeedit.py
@@ -1,6 +1,7 @@
 """
 Tests for scheme document.
 """
+import re
 import sys
 import unittest
 from unittest import mock
@@ -408,6 +409,15 @@ class TestSchemeEdit(QAppTestCase):
         a.trigger()
         self.assertEqual(len(workflow.nodes), 2 * nnodes)
         self.assertEqual(len(workflow.links), 2 * nlinks)
+        w.selectAll()
+        a.trigger()
+        self.assertEqual(len(workflow.nodes), 4 * nnodes)
+        self.assertEqual(len(workflow.links), 4 * nlinks)
+        self.assertEqual(len(workflow.nodes),
+                         len(set(n.title for n in workflow.nodes)))
+        match = re.compile(r"\(\d+\)\s*\(\d+\)")
+        self.assertFalse(any(match.search(n.title) for n in workflow.nodes),
+                         "Duplicated renumbering ('foo (2) (1)')")
 
     def test_copy_paste(self):
         w = self.w


### PR DESCRIPTION
### Issue

Closes: https://github.com/biolab/orange3/issues/6893

### Changes

Avoid replicated node renumbering on paste