### PR TITLE
[FIX] Fix bold fonts on Qt5 on Macs (apply QTBUG-58610 fix only on Windows)

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -365,6 +365,7 @@ application/application.py:
             -style: false
             styleHints: false
             setShowShortcutsInContextMenus: false
+            win32: false
             QMessageBox: false
         def `argumentParser`:
             -style: false

--- a/orangecanvas/application/application.py
+++ b/orangecanvas/application/application.py
@@ -151,7 +151,7 @@ class CanvasApplication(QApplication):
                 sh.setShowShortcutsInContextMenus(True)
         if QT_VERSION_INFO < (5, 15):  # QTBUG-61707
             macos_set_nswindow_tabbing(False)
-        if QT_VERSION_INFO < (6, 0):  # QTBUG-58610
+        if QT_VERSION_INFO < (6, 0) and sys.platform == "win32":  # QTBUG-58610
             # https://github.com/musescore/MuseScore/pull/5820
             QApplication.setFont(QApplication.font("QMessageBox"))
         self.configureStyle()


### PR DESCRIPTION
Fixes #314. I did not test how this looks on Windows, but it should not change anything since both 32 and 64-bit windows are `win32`