### PR TITLE
[FIX] pkgmeta: Support PEP-610 direct_url.json

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -2435,7 +2435,6 @@ help/manager.py:
         data: false
         URL: false
         DEVELOP_ROOT: false
-        .: false
     def `create_intersphinx_provider`:
         objects.inv: false
         Local doc root '%s' does not exist.: false
@@ -3514,11 +3513,19 @@ utils/pkgmeta.py:
     parse_meta: false
     get_dist_meta: false
     get_distribution: false
+    develop_root: false
+    get_dist_url: false
     def `normalize_name`:
         [-_.]+: false
         -: false
         _: false
-    def `is_develop_egg`:
+    def `_direct_url`:
+        direct_url.json: false
+    def `develop_root`:
+        dir_info: false
+        editable: false
+        url: false
+        file: false
         {normalize_name(dist.name)}.egg-info/: false
         setup.py: false
     def `trim`:

--- a/orangecanvas/help/manager.py
+++ b/orangecanvas/help/manager.py
@@ -15,7 +15,7 @@ from typing import Dict, Optional, List, Tuple, Union, Callable, Sequence
 
 from AnyQt.QtCore import QObject, QUrl, QDir
 
-from ..utils.pkgmeta import get_dist_url, is_develop_egg, get_distribution
+from ..utils.pkgmeta import get_dist_url, get_distribution, develop_root
 from . import provider
 
 if typing.TYPE_CHECKING:
@@ -154,8 +154,8 @@ def _replacements_for_dist(dist):
     except KeyError:
         pass
 
-    if is_develop_egg(dist):
-        replacements["DEVELOP_ROOT"] = str(dist.locate_file("."))
+    if develop_root(dist) is not None:
+        replacements["DEVELOP_ROOT"] = develop_root(dist)
 
     return replacements
 

--- a/orangecanvas/utils/tests/test_pkgmeta.py
+++ b/orangecanvas/utils/tests/test_pkgmeta.py
@@ -1,8 +1,9 @@
+import os
 from unittest import TestCase
 
 from orangecanvas.utils.pkgmeta import (
     Distribution, normalize_name, is_develop_egg, get_dist_meta, parse_meta,
-    trim,
+    trim, develop_root,
 )
 
 
@@ -19,6 +20,20 @@ class TestPkgMeta(TestCase):
             pass
         else:
             is_develop_egg(d)
+
+    def test_develop_root(self):
+        d = Distribution.from_name("AnyQt")
+        path = develop_root(d)
+        if path is not None:
+            self.assertTrue(os.path.isfile(d.locate_file("setup.py")))
+        try:
+            d = Distribution.from_name("orange-canvas-core")
+        except Exception:
+            pass
+        else:
+            path = develop_root(d)
+            if path is not None:
+                self.assertTrue(os.path.isfile(d.locate_file("setup.py")))
 
     def test_get_dist_meta(self):
         d = Distribution.from_name("AnyQt")


### PR DESCRIPTION
### Issue

Fixes: https://github.com/biolab/orange-canvas-core/issues/317

Since some time pip install -e ... installs a ${NAME}.dist-info dir into site-packages with a direct_url.json recording its origin.
This confuses importlib.metadata (https://github.com/python/cpython/issues/96144)

### Changes 

Support PEP-610 direct_url.json