### PR TITLE
Signal manager: Add a tooltip about mismatching types

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1290,13 +1290,11 @@ application/utils/addons.py:
             install: false
             --yes: false
             --quiet: false
-            --satisfied-skip-solve: false
         def `upgrade`:
             ={}: false
             install: false
             --yes: false
             --quiet: false
-            --satisfied-skip-solve: false
         def `uninstall`:
             uninstall: false
             --yes: false
@@ -1458,6 +1456,8 @@ canvas/items/linkitem.py:
         def `__updateText`:
             <nobr>{0}</nobr> \u2192 <nobr>{1}</nobr>: false
             '<div align="center" style="font-size: small" >{0}</div>': false
+        def `__update_tooltip`:
+            {self.sourceItem.title()} is not providing the proper data type required by {self.sinkItem.title()}: {self.sourceItem.title()} ni priskrbel pravilnega podatkovnega tipa za {self.sinkItem.title()}
         def `__updatePen`:
             '#9CACB4': false
             '#959595': false

--- a/orangecanvas/canvas/items/linkitem.py
+++ b/orangecanvas/canvas/items/linkitem.py
@@ -311,6 +311,8 @@ class LinkItem(QGraphicsWidget):
                     self.sourceItem.removeOutputAnchor(self.sourceAnchor)
                     self.sourceItem.selectedChanged.disconnect(
                         self.__updateSelectedState)
+                    self.sourceItem.titleEditingFinished.disconnect(
+                        self.__update_tooltip)
                 self.sourceItem = self.sourceAnchor = None
 
             self.sourceItem = item
@@ -320,6 +322,7 @@ class LinkItem(QGraphicsWidget):
                 anchor = item.newOutputAnchor(signal)
             if item is not None:
                 item.selectedChanged.connect(self.__updateSelectedState)
+                item.titleEditingFinished.connect(self.__update_tooltip)
 
         if anchor != self.sourceAnchor:
             if self.sourceAnchor is not None:
@@ -356,11 +359,13 @@ class LinkItem(QGraphicsWidget):
                 self.sinkAnchor.scenePositionChanged.disconnect(
                     self._sinkPosChanged
                 )
-
                 if self.sinkItem is not None:
                     self.sinkItem.removeInputAnchor(self.sinkAnchor)
                     self.sinkItem.selectedChanged.disconnect(
                         self.__updateSelectedState)
+                    self.sinkItem.titleEditingFinished.disconnect(
+                        self.__update_tooltip
+                    )
                 self.sinkItem = self.sinkAnchor = None
 
             self.sinkItem = item
@@ -370,6 +375,7 @@ class LinkItem(QGraphicsWidget):
                 anchor = item.newInputAnchor(signal)
             if item is not None:
                 item.selectedChanged.connect(self.__updateSelectedState)
+                item.titleEditingFinished.connect(self.__update_tooltip)
 
         if self.sinkAnchor != anchor:
             if self.sinkAnchor is not None:
@@ -670,6 +676,13 @@ class LinkItem(QGraphicsWidget):
             self.__dynamicEnabled = enabled
             if self.__dynamic:
                 self.__updatePen()
+        self.__update_tooltip()
+
+    def __update_tooltip(self):
+        if self.__dynamicEnabled:
+            self.curveItem.setToolTip(None)
+        else:
+            self.curveItem.setToolTip(f"{self.sourceItem.title()} is not providing the proper data type required by {self.sinkItem.title()}")
 
     def isDynamicEnabled(self):
         # type: () -> bool

--- a/orangecanvas/canvas/items/tests/test_linkitem.py
+++ b/orangecanvas/canvas/items/tests/test_linkitem.py
@@ -12,31 +12,39 @@ from . import TestItems
 
 
 class TestLinkItem(TestItems):
-    def test_linkitem(self):
+    def setUp(self):
+        super().setUp()
+
         reg = small_testing_registry()
 
         const_desc = reg.category("Constants")
 
         one_desc = reg.widget("one")
 
-        one_item = NodeItem()
+        self.one_item = one_item = NodeItem()
         one_item.setWidgetDescription(one_desc)
         one_item.setWidgetCategory(const_desc)
-        one_item.setPos(0, 100)
 
         negate_desc = reg.widget("negate")
 
-        negate_item = NodeItem()
+        self.negate_item = negate_item = NodeItem()
         negate_item.setWidgetDescription(negate_desc)
         negate_item.setWidgetCategory(const_desc)
-        negate_item.setPos(200, 100)
         operator_desc = reg.category("Operators")
 
         add_desc = reg.widget("add")
 
-        nb_item = NodeItem()
+        self.nb_item = nb_item = NodeItem()
         nb_item.setWidgetDescription(add_desc)
         nb_item.setWidgetCategory(operator_desc)
+
+    def test_linkitem(self):
+        one_item = self.one_item
+        negate_item = self.negate_item
+        nb_item = self.nb_item
+
+        one_item.setPos(0, 100)
+        negate_item.setPos(200, 100)
         nb_item.setPos(400, 100)
 
         self.scene.addItem(one_item)
@@ -92,15 +100,15 @@ class TestLinkItem(TestItems):
 
     def test_dynamic_link(self):
         link = LinkItem()
-        anchor1 = AnchorPoint()
-        anchor2 = AnchorPoint()
+        anchor1 = self.one_item.newOutputAnchor()
+        anchor2 = self.nb_item.newInputAnchor()
 
         self.scene.addItem(link)
         self.scene.addItem(anchor1)
         self.scene.addItem(anchor2)
 
-        link.setSourceItem(None, anchor=anchor1)
-        link.setSinkItem(None, anchor=anchor2)
+        link.setSourceItem(self.one_item, anchor=anchor1)
+        link.setSinkItem(self.nb_item, anchor=anchor2)
 
         anchor2.setPos(100, 100)
 
@@ -112,6 +120,21 @@ class TestLinkItem(TestItems):
 
         link.setDynamicEnabled(True)
         self.assertTrue(link.isDynamicEnabled())
+        self.assertEqual(link.curveItem.toolTip(), "")
+
+        link.setDynamicEnabled(False)
+        self.assertIn("one", link.curveItem.toolTip())
+        self.assertIn("add", link.curveItem.toolTip())
+
+        self.one_item.setTitle("new name for source")
+        self.one_item.titleEditingFinished.emit()
+        self.assertIn("new name for source", link.curveItem.toolTip())
+        self.assertIn("add", link.curveItem.toolTip())
+
+        self.nb_item.setTitle("new name for sink")
+        self.nb_item.titleEditingFinished.emit()
+        self.assertIn("new name for source", link.curveItem.toolTip())
+        self.assertIn("new name for sink", link.curveItem.toolTip())
 
         def advance():
             clock = time.process_time()
@@ -126,12 +149,12 @@ class TestLinkItem(TestItems):
 
     def test_link_enabled(self):
         link = LinkItem()
-        anchor1 = AnchorPoint()
-        anchor2 = AnchorPoint()
+        anchor1 = self.one_item.newOutputAnchor()
+        anchor2 = self.nb_item.newInputAnchor()
         anchor2.setPos(100, 100)
 
-        link.setSourceItem(None, anchor=anchor1)
-        link.setSinkItem(None, anchor=anchor2)
+        link.setSourceItem(self.one_item, anchor=anchor1)
+        link.setSinkItem(self.nb_item, anchor=anchor2)
 
         link.setEnabled(False)
         self.assertFalse(link.isEnabled())


### PR DESCRIPTION
I drafted something and I know it's ugly:

- It assumes that `__dynamicEnabled` being false is always a consequence of type mismatch. (True for now, but not necessarily in the future.)
- It doesn't update the tooltip if the user renames the source or sink widget after sending the data. (Minor glitch, but still...)

The latter would require connecting some distant signals, the former requires checking the reason for mismatch (i.e. comparing the signal types).

@ales-erjavec: is this a useful start or would you approach it differently?

@ajdapretnar: is the message OK?

![Screenshot 2025-03-07 at 11 19 07](https://github.com/user-attachments/assets/fc2ac3e1-d3f7-4a5d-a4f9-cd7a74ca7b05)
