### PR TITLE
[FIX] addons: Use QTimer.singleShot to exit/restart

### DIFF
--- a/orangecanvas/application/addons.py
+++ b/orangecanvas/application/addons.py
@@ -963,7 +963,8 @@ class AddonManagerDialog(QDialog):
                         icon=QMessageBox.Information
                     ).exec()
                 else:
-                    QApplication.exit(96)
+                    # Sometimes it doesn't actually exit unless this call is queued
+                    QTimer.singleShot(0, lambda: QApplication.exit(96))
 
             QTimer.singleShot(0, restart)
         else:


### PR DESCRIPTION
### Issue

Fix https://github.com/biolab/orange-canvas-core/issues/325 (or at least attempt)

### Changes

Queue the exit call instead of calling it directly. This seems to fix the issue, but I am not sure why.