### PR TITLE
[MNT] CI: Update runners

### DIFF
--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: False
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python: "3.10"
 
     steps:

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -20,7 +20,7 @@ jobs:
         libxcb-render-util0
         libxcb-xinerama0
         libxcb-xfixes0
-        libegl1-mesa
+        libegl1
         libxcb-shape0
         libxcb-cursor0
         glibc-tools

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -41,7 +41,7 @@ jobs:
 
           - os: ubuntu-latest
             python-version: "3.13"
-            test-env: "PyQt6~=6.7.0 PyQt6-Qt6~=6.7.0"
+            test-env: "PyQt6~=6.8.0 PyQt6-Qt6~=6.8.0"
             extra-system-packages: "glibc-tools"
 
           # macOS
@@ -67,7 +67,7 @@ jobs:
 
           - os: macos-latest
             python-version: "3.13"
-            test-env: "PyQt6~=6.7.0 PyQt6-Qt6~=6.7.0"
+            test-env: "PyQt6~=6.8.0 PyQt6-Qt6~=6.8.0"
 
           # Windows
           - os: windows-2022
@@ -92,7 +92,7 @@ jobs:
 
           - os: windows-latest
             python-version: "3.13"
-            test-env: "PyQt6~=6.7.0 PyQt6-Qt6~=6.7.0"
+            test-env: "PyQt6~=6.8.0 PyQt6-Qt6~=6.8.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -17,29 +17,29 @@ jobs:
       matrix:
         include:
           # Linux
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: "3.11"
             test-env: "PyQt5~=5.15.0"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: "3.11"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
             extra-system-packages: "glibc-tools"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: "3.12"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
             extra-system-packages: "glibc-tools"
 
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             python-version: "3.13"
             test-env: "PyQt6~=6.7.0 PyQt6-Qt6~=6.7.0"
             extra-system-packages: "glibc-tools"
@@ -70,27 +70,27 @@ jobs:
             test-env: "PyQt6~=6.7.0 PyQt6-Qt6~=6.7.0"
 
           # Windows
-          - os: windows-2019
+          - os: windows-2022
             python-version: "3.10"
             test-env: "PyQt5~=5.15.0"
 
-          - os: windows-2019
+          - os: windows-2022
             python-version: "3.11"
             test-env: "PyQt5~=5.15.0"
 
-          - os: windows-2019
+          - os: windows-2022
             python-version: "3.11"
             test-env: "PyQt6~=6.2.3 PyQt6-Qt6~=6.2.3"
 
-          - os: windows-2019
+          - os: windows-latest
             python-version: "3.11"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
 
-          - os: windows-2019
+          - os: windows-latest
             python-version: "3.12"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
 
-          - os: windows-2019
+          - os: windows-latest
             python-version: "3.13"
             test-env: "PyQt6~=6.7.0 PyQt6-Qt6~=6.7.0"
 

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -11,6 +11,19 @@ jobs:
       PIP_NO_PIP_VERSION_CHECK: 1
       PIP_CACHE_DIR: .pip-cache
       PIP_PREFER_BINARY: 1
+      UBUNTU_SYSTEM_PACKAGES: |
+        libxkbcommon-x11-0
+        libxcb-icccm4
+        libxcb-image0
+        libxcb-keysyms1
+        libxcb-randr0
+        libxcb-render-util0
+        libxcb-xinerama0
+        libxcb-xfixes0
+        libegl1-mesa
+        libxcb-shape0
+        libxcb-cursor0
+        glibc-tools
 
     strategy:
       fail-fast: False
@@ -32,17 +45,14 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.11"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
-            extra-system-packages: "glibc-tools"
 
           - os: ubuntu-latest
             python-version: "3.12"
             test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
-            extra-system-packages: "glibc-tools"
 
           - os: ubuntu-latest
             python-version: "3.13"
             test-env: "PyQt6~=6.8.0 PyQt6-Qt6~=6.8.0"
-            extra-system-packages: "glibc-tools"
 
           # macOS
           - os: macos-13
@@ -108,7 +118,7 @@ jobs:
         # https://www.riverbankcomputing.com/pipermail/pyqt/2020-June/042949.html
         run: |
           sudo apt-get update 
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0 libxcb-cursor0 $PACKAGES
+          sudo apt-get install -y $UBUNTU_SYSTEM_PACKAGES $PACKAGES
 
       - name: Setup Pip Cache
         uses: actions/cache@v4


### PR DESCRIPTION
### Issue

GH Actions runner images are deprecated

### Changes

Update ubuntu-20.04 to ubuntu-22.04 and windows-2019 to windows-2022
