### PR TITLE
Replace Feedback with Donate

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1123,7 +1123,7 @@ WelcomeActionButton:focus {
             bottom-bar: false
             Show at startup: Pokaži ob zagonu
         def `setFeedbackUrl`:
-            Help us improve!: Pomagaj, da bomo še boljši
+            Donate: Doniraj
             <a href="{url}">{text}</a>: false
         def `addRow`:
             light-orange: false

--- a/orangecanvas/application/welcomedialog.py
+++ b/orangecanvas/application/welcomedialog.py
@@ -194,7 +194,7 @@ class WelcomeDialog(QDialog):
         """
         self.__feedbackUrl = url
         if url:
-            text = self.tr("Help us improve!")
+            text = self.tr("Donate")
             self.__feedbackLabel.setText(
                 '<a href="{url}">{text}</a>'.format(url=url, text=escape(text))
             )


### PR DESCRIPTION
The link to the survey was long-defunct. Currently, the only sensible substitution is to have a Donate button there.

Unsure about changing this directly in canvas. Perhaps there's a way to override the label in Orange? Or do we just remove the feedbackUrl and display nothing?