### PR TITLE
[ENH] UserInteraction can be extended by shift.

### DIFF
--- a/orangecanvas/document/interactions.py
+++ b/orangecanvas/document/interactions.py
@@ -116,6 +116,7 @@ class UserInteraction(QObject):
         self.deleteOnEnd = deleteOnEnd
 
         self.cancelOnEsc = False
+        self.extendedOnShift = False
 
         self.__finished = False
         self.__canceled = False
@@ -1414,6 +1415,9 @@ class NewArrowAnnotation(UserInteraction):
 
                 p1, p2 = map(self.arrow_item.mapFromScene, (p1, p2))
                 self.arrow_item.setLine(QLineF(p1, p2))
+
+            if event.modifiers() & Qt.ShiftModifier:
+                self.extendedOnShift = True
 
             self.end()
             return True

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -1913,7 +1913,7 @@ class SchemeEditWidget(QWidget):
             handler = self.__scene.user_interaction_handler
             if isinstance(handler, interactions.NewArrowAnnotation):
                 # Cancel the interaction and restore the state
-                handler.ended.disconnect(action.toggle)
+                handler.ended.disconnect(self.__toggleNewArrowAction)
                 handler.cancel(interactions.UserInteraction.UserCancelReason)
                 log.info("Canceled new arrow annotation")
 
@@ -1922,9 +1922,17 @@ class SchemeEditWidget(QWidget):
             checked_action = self.__arrowColorActionGroup.checkedAction()
             handler.setColor(checked_action.data())
 
-            handler.ended.connect(action.toggle)
+            handler.ended.connect(self.__toggleNewArrowAction)
 
             self._setUserInteractionHandler(handler)
+
+    def __toggleNewArrowAction(self):
+        handler = self.sender()
+        action = self.__newArrowAnnotationAction
+        action.toggle()  # end current
+        if handler.extendedOnShift:
+            handler.extendedOnShift = False  # clear shift flag
+            action.toggle()  # start new
 
     def __onFontSizeTriggered(self, action):
         # type: (QAction) -> None


### PR DESCRIPTION
Hello,

Like in description: _Added flag for keep state across whole user interactions (in UserInteraction class) and implement it for ArrowAnnotation._

I Pull Request this feature, because I think this is some kind of intuitive and decrease mouse move when we repeat the same operation.

Of course `shift` is my personal choice, so if `ctrl` be better, the change is straightforward.