### PR TITLE
[ENH] SchemeEditorWidget: Link menu public interface

### DIFF
--- a/orangecanvas/application/canvasmain.py
+++ b/orangecanvas/application/canvasmain.py
@@ -133,6 +133,9 @@ class DockWidget(QDockWidget):
 class CanvasMainWindow(QMainWindow):
     SETTINGS_VERSION = 3
 
+    #: The central workflow editor constructor.
+    EDITOR_WIDGET_CONSTRUCTOR = SchemeEditWidget
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -203,7 +206,7 @@ class CanvasMainWindow(QMainWindow):
         w.setLayout(QVBoxLayout())
         w.layout().setContentsMargins(20, 0, 10, 0)
 
-        self.scheme_widget = SchemeEditWidget()
+        self.scheme_widget = self.EDITOR_WIDGET_CONSTRUCTOR()
         self.scheme_widget.setDropHandlers([interactions.PluginDropHandler(),])
         self.set_scheme(config.workflow_constructor(parent=self))
 

--- a/orangecanvas/document/schemeedit.py
+++ b/orangecanvas/document/schemeedit.py
@@ -549,6 +549,20 @@ class SchemeEditWidget(QWidget):
         layout.addWidget(view)
         self.setLayout(layout)
 
+    def linkMenu(self) -> QMenu:
+        """
+        Return the default 'link' context menu.
+        """
+        return self.__linkMenu
+
+    def contextMenuForLink(self, link: SchemeLink) -> QMenu:
+        """
+        Return a `QMenu` for a context click on the connection represented
+        by `link`.
+        """
+        UNUSED(link)
+        return self.linkMenu()
+
     def __setupScene(self, scene):
         # type: (CanvasScene) -> None
         """
@@ -1688,7 +1702,8 @@ class SchemeEditWidget(QWidget):
             link = self.scene().link_for_item(item)
             self.__linkEnableAction.setChecked(link.enabled)
             self.__contextMenuTarget = link
-            self.__linkMenu.popup(globalPos)
+            menu = self.contextMenuForLink(link)
+            menu.popup(globalPos)
             return True
 
         item = self.scene().item_at(scenePos)

--- a/orangecanvas/document/tests/test_schemeedit.py
+++ b/orangecanvas/document/tests/test_schemeedit.py
@@ -362,6 +362,12 @@ class TestSchemeEdit(QAppTestCase):
         self.assertEqual(w.scheme().annotations, [])
         self.assertEqual(w.scheme().links, [])
 
+    def _point_on_link_curve(self, link: SchemeLink) -> QPoint:
+        scene, view = self.w.scene(), self.w.view()
+        item: items.LinkItem = scene.item_for_link(link)
+        path = item.curveItem.curvePath()
+        return view.mapFromScene(item.mapToScene(path).pointAtPercent(0.5))
+
     def test_select_remove_link(self):
         def link_curve(link: SchemeLink) -> QPainterPath:
             item = scene.item_for_link(link)  # type: items.LinkItem
@@ -399,6 +405,18 @@ class TestSchemeEdit(QAppTestCase):
         self.assertSequenceEqual(list(spyrem), [[target]])
         self.assertEqual(len(spyadd), 2)
         w.undoStack().undo()
+
+    def test_link_context_menu(self):
+        w = self.w
+        workflow = self.setup_test_workflow(w.scheme())
+        link = workflow.links[0]
+        self.assertIs(w.linkMenu(), w.contextMenuForLink(link))
+        p = self._point_on_link_curve(link)
+        with mock.patch.object(
+                w, "contextMenuForLink", wraps=w.contextMenuForLink
+        ) as m:
+            contextMenu(w.view().viewport(), p)
+            m.assert_called_once_with(link)
 
     def test_align_to_grid(self):
         w = self.w
@@ -687,10 +705,10 @@ class TestSchemeEdit(QAppTestCase):
         add_desc = reg.widget("add")
         negate = reg.widget("negate")
 
-        zero_node = SchemeNode(zero_desc)
-        one_node = SchemeNode(one_desc)
-        add_node = SchemeNode(add_desc)
-        negate_node = SchemeNode(negate)
+        zero_node = SchemeNode(zero_desc, position=(0, 0))
+        one_node = SchemeNode(one_desc, position=(0, 200))
+        add_node = SchemeNode(add_desc, position=(200, 100))
+        negate_node = SchemeNode(negate, position=(400, 100))
 
         scheme.add_node(zero_node)
         scheme.add_node(one_node)

--- a/orangecanvas/resources.py
+++ b/orangecanvas/resources.py
@@ -204,7 +204,7 @@ class icon_loader(resource_loader):
             return QIcon(self._icon_cache[cache_key])
 
         if len(icons) == 1 and icons[0].lower().endswith(".svg"):
-            if self.package is not None:
+            if self.package is not None and name:
                 try:
                     contents = pkgutil.get_data(self.package, name)
                 except FileNotFoundError:


### PR DESCRIPTION
Ref: #347

Expose link menu in public interface

Overide `SchemeEditorWidget.contextMenuForLink` method in a subclass to modify/replace default menu.
In order to use a subclass of `SchemeEditorWidget` it is also necessary to subclass `CanvasMainWindow` and define `EDITOR_WIDGET_CONSTRUCTOR`.

