### PR TITLE
[MNT] CI: Bump PyQt6 versions in the test matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     name: Build distribution files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -25,7 +25,7 @@ jobs:
         run: python -m build --wheel .
 
       - name: Upload dist files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-sdist
           path: dist/*
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # unpacks all dist artifacts into dist/
           pattern: dist-*
@@ -61,7 +61,7 @@ jobs:
     if: always() && !failure() && !cancelled() && startsWith(github.ref, 'refs/tags')
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # unpacks all dist artifacts into dist/
           pattern: dist-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,4 +73,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: dist/
+          packages-dir: dist/

--- a/.github/workflows/run-docs-build.yml
+++ b/.github/workflows/run-docs-build.yml
@@ -19,14 +19,14 @@ jobs:
             python: "3.10"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
       - name: Setup Pip Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-docs-build.yml') }}

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -44,15 +44,15 @@ jobs:
 
           - os: ubuntu-latest
             python-version: "3.12"
-            test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
-
-          - os: ubuntu-latest
-            python-version: "3.13"
             test-env: "PyQt6~=6.8.0 PyQt6-Qt6~=6.8.0"
 
           - os: ubuntu-latest
+            python-version: "3.13"
+            test-env: "PyQt6~=6.10.0 PyQt6-Qt6~=6.10.0"
+
+          - os: ubuntu-latest
             python-version: "3.14"
-            test-env: "PyQt6~=6.9.0 PyQt6-Qt6~=6.9.0"
+            test-env: "PyQt6~=6.11.0 PyQt6-Qt6~=6.11.0"
 
           # macOS
           - os: macos-14
@@ -69,15 +69,15 @@ jobs:
 
           - os: macos-latest
             python-version: "3.12"
-            test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
-
-          - os: macos-latest
-            python-version: "3.13"
             test-env: "PyQt6~=6.8.0 PyQt6-Qt6~=6.8.0"
 
           - os: macos-latest
+            python-version: "3.13"
+            test-env: "PyQt6~=6.10.0 PyQt6-Qt6~=6.10.0"
+
+          - os: macos-latest
             python-version: "3.14"
-            test-env: "PyQt6~=6.9.0 PyQt6-Qt6~=6.9.0"
+            test-env: "PyQt6~=6.11.0 PyQt6-Qt6~=6.11.0"
 
           # Windows
           - os: windows-2022
@@ -94,15 +94,15 @@ jobs:
 
           - os: windows-latest
             python-version: "3.12"
-            test-env: "PyQt6~=6.5.0 PyQt6-Qt6~=6.5.0"
-
-          - os: windows-latest
-            python-version: "3.13"
             test-env: "PyQt6~=6.8.0 PyQt6-Qt6~=6.8.0"
 
           - os: windows-latest
+            python-version: "3.13"
+            test-env: "PyQt6~=6.10.0 PyQt6-Qt6~=6.10.0"
+
+          - os: windows-latest
             python-version: "3.14"
-            test-env: "PyQt6~=6.9.0 PyQt6-Qt6~=6.9.0"
+            test-env: "PyQt6~=6.11.0 PyQt6-Qt6~=6.11.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -105,9 +105,9 @@ jobs:
             test-env: "PyQt6~=6.11.0 PyQt6-Qt6~=6.11.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -121,7 +121,7 @@ jobs:
           sudo apt-get install -y $UBUNTU_SYSTEM_PACKAGES $PACKAGES
 
       - name: Setup Pip Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .pip-cache
           key: ${{ runner.os }}-py-${{ matrix.python-version }}-pip-${{ hashFiles('setup.*', '.github/workflows/run-tests-workflow.yml') }}
@@ -165,6 +165,6 @@ jobs:
           catchsegv xvfb-run -a -s "$XVFBARGS" python -m orangecanvas --help
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
* Bump PyQt6 versions in the test matrix (in particular include PyQt6 6.11)
* Also bump gh actions versions to avoid node 20 deprecation warnings in CI logs