### PR TITLE
[FIX] linkitem: Fix link text direction inversion

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1490,7 +1490,8 @@ canvas/items/linkitem.py:
         def `setSinkItem`:
             Anchor must be belong to the item: false
         def `__updateText`:
-            <nobr>{0}</nobr> \u2192 <nobr>{1}</nobr>: false
+            <nobr>{sink}</nobr> \u2190 <nobr>{source}</nobr>: false
+            <nobr>{source}</nobr> \u2192 <nobr>{sink}</nobr>: false
             '<div align="center" style="font-size: small" >{0}</div>': false
         def `__update_tooltip`:
             {self.sourceItem.title()} is not providing the proper data type required by {self.sinkItem.title()}: {self.sourceItem.title()} ni priskrbel pravilnega podatkovnega tipa za {self.sinkItem.title()}

--- a/orangecanvas/canvas/items/linkitem.py
+++ b/orangecanvas/canvas/items/linkitem.py
@@ -482,12 +482,20 @@ class LinkItem(QGraphicsWidget):
         # type: () -> None
         self.prepareGeometryChange()
         self.__boundingRect = None
+        angle = 0
+        path = self.curveItem.curvePath()
+        if not path.isEmpty():
+            angle = path.angleAtPercent(0.5)
 
         if self.__sourceName or self.__sinkName:
             if self.__sourceName != self.__sinkName:
-                text = ("<nobr>{0}</nobr> \u2192 <nobr>{1}</nobr>"
-                        .format(escape(self.__sourceName),
-                                escape(self.__sinkName)))
+                source = escape(self.__sourceName)
+                sink = escape(self.__sinkName)
+                if 90 <= angle < 270:
+                    text = f"<nobr>{sink}</nobr> \u2190 <nobr>{source}</nobr>"
+                else:
+                    text = f"<nobr>{source}</nobr> \u2192 <nobr>{sink}</nobr>"
+
             else:
                 # If the names are the same show only one.
                 # Is this right? If the sink has two input channels of the
@@ -500,7 +508,7 @@ class LinkItem(QGraphicsWidget):
         self.linkTextItem.setHtml(
             '<div align="center" style="font-size: small" >{0}</div>'
             .format(text))
-        path = self.curveItem.curvePath()
+
 
         # Constrain the text width if it is too long to fit on a single line
         # between the two ends


### PR DESCRIPTION
### Issue 

When links go *backwards* the text on the link is misleading:
<img width="205" height="190" alt="Screenshot 2026-06-26 at 09 04 23" src="https://github.com/user-attachments/assets/c9366c46-a06a-454a-8448-5e74e00ab672" />


### Changes

* Fix link text direction inversion
<img width="198" height="198" alt="Screenshot 2026-06-26 at 09 04 56" src="https://github.com/user-attachments/assets/999c4933-abe7-494a-8126-a7c679e42142" />
